### PR TITLE
Only expose jaeger query ports if jaeger-query is enabled

### DIFF
--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -202,6 +202,19 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 func services(tempo v1alpha1.Microservices) []*corev1.Service {
 	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
 
+	jaegerPorts := []corev1.ServicePort{
+		{
+			Name:       tempoQueryJaegerUiPortName,
+			Port:       portJaegerUI,
+			TargetPort: intstr.FromInt(portJaegerUI),
+		},
+		{
+			Name:       tempoQueryMetricsPortName,
+			Port:       portQueryMetrics,
+			TargetPort: intstr.FromString("jaeger-metrics"),
+		},
+	}
+
 	frontEndService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      manifestutils.Name(componentName, tempo.Name),
@@ -220,16 +233,6 @@ func services(tempo v1alpha1.Microservices) []*corev1.Service {
 					Protocol:   corev1.ProtocolTCP,
 					Port:       portGRPCServer,
 					TargetPort: intstr.FromInt(portGRPCServer),
-				},
-				{
-					Name:       tempoQueryJaegerUiPortName,
-					Port:       portJaegerUI,
-					TargetPort: intstr.FromInt(portJaegerUI),
-				},
-				{
-					Name:       tempoQueryMetricsPortName,
-					Port:       portQueryMetrics,
-					TargetPort: intstr.FromString("jaeger-metrics"),
 				},
 			},
 			Selector: labels,
@@ -256,16 +259,6 @@ func services(tempo v1alpha1.Microservices) []*corev1.Service {
 					TargetPort: intstr.FromInt(portGRPCServer),
 				},
 				{
-					Name:       tempoQueryJaegerUiPortName,
-					Port:       portJaegerUI,
-					TargetPort: intstr.FromInt(portJaegerUI),
-				},
-				{
-					Name:       tempoQueryMetricsPortName,
-					Port:       portQueryMetrics,
-					TargetPort: intstr.FromString("jaeger-metrics"),
-				},
-				{
 					Name:       grpclbPortName,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       portGRPCLBServer,
@@ -274,6 +267,11 @@ func services(tempo v1alpha1.Microservices) []*corev1.Service {
 			},
 			Selector: labels,
 		},
+	}
+
+	if tempo.Spec.Components.QueryFrontend != nil && tempo.Spec.Components.QueryFrontend.JaegerQuery.Enabled {
+		frontEndService.Spec.Ports = append(frontEndService.Spec.Ports, jaegerPorts...)
+		frontEndDiscoveryService.Spec.Ports = append(frontEndDiscoveryService.Spec.Ports, jaegerPorts...)
 	}
 
 	return []*corev1.Service{frontEndService, frontEndDiscoveryService}

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -202,19 +202,6 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 func services(tempo v1alpha1.Microservices) []*corev1.Service {
 	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
 
-	jaegerPorts := []corev1.ServicePort{
-		{
-			Name:       tempoQueryJaegerUiPortName,
-			Port:       portJaegerUI,
-			TargetPort: intstr.FromInt(portJaegerUI),
-		},
-		{
-			Name:       tempoQueryMetricsPortName,
-			Port:       portQueryMetrics,
-			TargetPort: intstr.FromString("jaeger-metrics"),
-		},
-	}
-
 	frontEndService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      manifestutils.Name(componentName, tempo.Name),
@@ -270,6 +257,19 @@ func services(tempo v1alpha1.Microservices) []*corev1.Service {
 	}
 
 	if tempo.Spec.Components.QueryFrontend != nil && tempo.Spec.Components.QueryFrontend.JaegerQuery.Enabled {
+		jaegerPorts := []corev1.ServicePort{
+			{
+				Name:       tempoQueryJaegerUiPortName,
+				Port:       portJaegerUI,
+				TargetPort: intstr.FromInt(portJaegerUI),
+			},
+			{
+				Name:       tempoQueryMetricsPortName,
+				Port:       portQueryMetrics,
+				TargetPort: intstr.FromString("jaeger-metrics"),
+			},
+		}
+
 		frontEndService.Spec.Ports = append(frontEndService.Spec.Ports, jaegerPorts...)
 		frontEndDiscoveryService.Spec.Ports = append(frontEndDiscoveryService.Spec.Ports, jaegerPorts...)
 	}


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This fixes #77 and also adds a test case where jaeger-query is enabled