### PR TITLE
Update README: fix minio endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ kind: Secret
 metadata:
   name: minio-test
 stringData:
-  endpoint: http://minio.minio-storage.svc:9000
+  endpoint: http://minio.minio.svc:9000
   bucket: tempo
   access_key_id: tempo
   access_key_secret: supersecret


### PR DESCRIPTION
Minio is deployed to the 'minio' namespace when following the instructions in the README.