### PR TITLE
Add common labels (including instance name) to the gossip ring selector

### DIFF
--- a/internal/manifests/manifestutils/naming.go
+++ b/internal/manifests/manifestutils/naming.go
@@ -16,12 +16,12 @@ func Name(component string, instanceName string) string {
 
 // ComponentLabels is a list of all commonLabels including the app.kubernetes.io/component:<component> label.
 func ComponentLabels(component, instanceName string) labels.Set {
-	return labels.Merge(commonLabels(instanceName), map[string]string{
+	return labels.Merge(CommonLabels(instanceName), map[string]string{
 		"app.kubernetes.io/component": component,
 	})
 }
 
-func commonLabels(instanceName string) map[string]string {
+func CommonLabels(instanceName string) map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":       "tempo",
 		"app.kubernetes.io/instance":   instanceName,

--- a/internal/manifests/memberlist/gossip.go
+++ b/internal/manifests/memberlist/gossip.go
@@ -3,6 +3,7 @@ package memberlist
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
@@ -21,6 +22,8 @@ var (
 // BuildGossip creates Kubernetes objects that are needed for memberlist.
 func BuildGossip(tempo v1alpha1.Microservices) *corev1.Service {
 	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
+	selector := k8slabels.Merge(manifestutils.CommonLabels(tempo.Name), GossipSelector)
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      manifestutils.Name(componentName, tempo.Name),
@@ -28,7 +31,7 @@ func BuildGossip(tempo v1alpha1.Microservices) *corev1.Service {
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: GossipSelector,
+			Selector: selector,
 			Ports: []corev1.ServicePort{
 				{
 					Name:       componentName,

--- a/internal/manifests/memberlist/gossip_test.go
+++ b/internal/manifests/memberlist/gossip_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
@@ -22,15 +22,16 @@ func TestBuildGossip(t *testing.T) {
 		},
 	})
 	labels := manifestutils.ComponentLabels("gossip-ring", "test")
+	selector := k8slabels.Merge(manifestutils.CommonLabels("test"), GossipSelector)
 	require.NotNil(t, service)
-	assert.Equal(t, &v1.Service{
+	assert.Equal(t, &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "tempo-test-gossip-ring",
 			Namespace: "ns1",
 			Labels:    labels,
 		},
-		Spec: v1.ServiceSpec{
-			Selector: GossipSelector,
+		Spec: corev1.ServiceSpec{
+			Selector: selector,
 			Ports: []corev1.ServicePort{
 				{
 					Name:       componentName,

--- a/tests/e2e/smoketest-with-jaeger/01-assert.yaml
+++ b/tests/e2e/smoketest-with-jaeger/01-assert.yaml
@@ -161,6 +161,10 @@ spec:
       protocol: TCP
       targetPort: http-memberlist
   selector:
+    app.kubernetes.io/created-by: tempo-controller
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-controller
+    app.kubernetes.io/name: tempo
     tempo-gossip-member: "true"
 ---
 apiVersion: v1


### PR DESCRIPTION
This is required to support multiple tempo instances in the same namespace.

Instead of updating the label name, it makes the selector of the gossip-ring service more strict to only match pods created by this controller (and with the same instance name). Is there any drawback to this vs. renaming the label per-instance?

Resolves: #71