### PR TITLE
Use a service account for all components

### DIFF
--- a/apis/tempo/v1alpha1/microservices_types.go
+++ b/apis/tempo/v1alpha1/microservices_types.go
@@ -16,6 +16,12 @@ type MicroservicesSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Container Images"
 	Images ImagesSpec `json:"images,omitempty"`
 
+	// ServiceAccount defines the service account to use for all tempo components.
+	//
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Service Account"
+	ServiceAccount string `json:"serviceAccount,omitempty"`
+
 	// NOTE: currently this field is not considered.
 	// Components defines requirements for a set of tempo components.
 	//

--- a/apis/tempo/v1alpha1/microservices_webhook_test.go
+++ b/apis/tempo/v1alpha1/microservices_webhook_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestDefault(t *testing.T) {
@@ -26,11 +27,15 @@ func TestDefault(t *testing.T) {
 		{
 			name: "no action default values are provided",
 			input: &Microservices{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
 				Spec: MicroservicesSpec{
 					Images: ImagesSpec{
 						Tempo:      "docker.io/grafana/tempo:1.2.3",
 						TempoQuery: "docker.io/grafana/tempo-query:1.2.3",
 					},
+					ServiceAccount: "tempo-test-serviceaccount",
 					Retention: RetentionSpec{
 						Global: RetentionConfig{
 							Traces: time.Hour,
@@ -47,11 +52,15 @@ func TestDefault(t *testing.T) {
 				},
 			},
 			expected: &Microservices{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
 				Spec: MicroservicesSpec{
 					Images: ImagesSpec{
 						Tempo:      "docker.io/grafana/tempo:1.2.3",
 						TempoQuery: "docker.io/grafana/tempo-query:1.2.3",
 					},
+					ServiceAccount: "tempo-test-serviceaccount",
 					Retention: RetentionSpec{
 						Global: RetentionConfig{
 							Traces: time.Hour,
@@ -69,14 +78,22 @@ func TestDefault(t *testing.T) {
 			},
 		},
 		{
-			name:  "default values are set in the webhook",
-			input: &Microservices{},
+			name: "default values are set in the webhook",
+			input: &Microservices{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
 			expected: &Microservices{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
 				Spec: MicroservicesSpec{
 					Images: ImagesSpec{
 						Tempo:      "docker.io/grafana/tempo:x.y.z",
 						TempoQuery: "docker.io/grafana/tempo-query:x.y.z",
 					},
+					ServiceAccount: "tempo-test-serviceaccount",
 					Retention: RetentionSpec{
 						Global: RetentionConfig{
 							Traces: 48 * time.Hour,

--- a/bundle/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tempo-operator.clusterserviceversion.yaml
@@ -158,6 +158,10 @@ spec:
         path: retention.perTenant.traces
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ServiceAccount defines the service account to use for all tempo
+          components.
+        displayName: Service Account
+        path: serviceAccount
       - description: 'NOTE: currently this field is not considered. Storage defines
           S3 compatible object storage configuration. User is required to create secret
           and supply it.'

--- a/bundle/manifests/tempo.grafana.com_microservices.yaml
+++ b/bundle/manifests/tempo.grafana.com_microservices.yaml
@@ -195,6 +195,10 @@ spec:
                     description: PerTenant is used to configure retention per tenant.
                     type: object
                 type: object
+              serviceAccount:
+                description: ServiceAccount defines the service account to use for
+                  all tempo components.
+                type: string
               storage:
                 description: 'NOTE: currently this field is not considered. Storage
                   defines S3 compatible object storage configuration. User is required

--- a/config/crd/bases/tempo.grafana.com_microservices.yaml
+++ b/config/crd/bases/tempo.grafana.com_microservices.yaml
@@ -196,6 +196,10 @@ spec:
                     description: PerTenant is used to configure retention per tenant.
                     type: object
                 type: object
+              serviceAccount:
+                description: ServiceAccount defines the service account to use for
+                  all tempo components.
+                type: string
               storage:
                 description: 'NOTE: currently this field is not considered. Storage
                   defines S3 compatible object storage configuration. User is required

--- a/config/manifests/bases/tempo-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/tempo-operator.clusterserviceversion.yaml
@@ -146,6 +146,10 @@ spec:
         path: retention.perTenant.traces
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ServiceAccount defines the service account to use for all tempo
+          components.
+        displayName: Service Account
+        path: serviceAccount
       - description: 'NOTE: currently this field is not considered. Storage defines
           S3 compatible object storage configuration. User is required to create secret
           and supply it.'

--- a/docs/api.md
+++ b/docs/api.md
@@ -119,6 +119,13 @@ MicroservicesSpec defines the desired state of Microservices.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>serviceAccount</b></td>
+        <td>string</td>
+        <td>
+          ServiceAccount defines the service account to use for all tempo components.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#microservicesspecstorage">storage</a></b></td>
         <td>object</td>
         <td>

--- a/internal/manifests/compactor/compactor.go
+++ b/internal/manifests/compactor/compactor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
+	"github.com/os-observability/tempo-operator/internal/manifests/serviceaccount"
 )
 
 const (
@@ -55,8 +56,9 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: cfg.NodeSelector,
-					Tolerations:  cfg.Tolerations,
+					ServiceAccountName: serviceaccount.ServiceAccountName(tempo),
+					NodeSelector:       cfg.NodeSelector,
+					Tolerations:        cfg.Tolerations,
 					Containers: []corev1.Container{
 						{
 							Name:  "tempo",

--- a/internal/manifests/compactor/compactor.go
+++ b/internal/manifests/compactor/compactor.go
@@ -11,7 +11,7 @@ import (
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
-	"github.com/os-observability/tempo-operator/internal/manifests/serviceaccount"
+	"github.com/os-observability/tempo-operator/internal/manifests/naming"
 )
 
 const (
@@ -43,7 +43,7 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 			APIVersion: v1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, tempo.Name),
+			Name:      naming.Name(componentName, tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},
@@ -56,7 +56,7 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: serviceaccount.ServiceAccountName(tempo),
+					ServiceAccountName: tempo.Spec.ServiceAccount,
 					NodeSelector:       cfg.NodeSelector,
 					Tolerations:        cfg.Tolerations,
 					Containers: []corev1.Container{
@@ -92,7 +92,7 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: manifestutils.Name("", tempo.Name),
+										Name: naming.Name("", tempo.Name),
 									},
 								},
 							},
@@ -114,7 +114,7 @@ func service(tempo v1alpha1.Microservices) *corev1.Service {
 	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, tempo.Name),
+			Name:      naming.Name(componentName, tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},

--- a/internal/manifests/compactor/compactor_test.go
+++ b/internal/manifests/compactor/compactor_test.go
@@ -95,7 +95,8 @@ func TestBuildCompactor(t *testing.T) {
 					Labels: k8slabels.Merge(labels, map[string]string{"tempo-gossip-member": "true"}),
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{"a": "b"},
+					ServiceAccountName: "tempo-test-serviceaccount",
+					NodeSelector:       map[string]string{"a": "b"},
 					Tolerations: []corev1.Toleration{
 						{
 							Key: "c",

--- a/internal/manifests/compactor/compactor_test.go
+++ b/internal/manifests/compactor/compactor_test.go
@@ -27,6 +27,7 @@ func TestBuildCompactor(t *testing.T) {
 			Images: v1alpha1.ImagesSpec{
 				Tempo: "docker.io/grafana/tempo:1.5.0",
 			},
+			ServiceAccount: "tempo-test-serviceaccount",
 			Components: v1alpha1.TempoComponentsSpec{
 				Compactor: &v1alpha1.TempoComponentSpec{
 					NodeSelector: map[string]string{"a": "b"},

--- a/internal/manifests/config/build.go
+++ b/internal/manifests/config/build.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
-	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
+	"github.com/os-observability/tempo-operator/internal/manifests/naming"
 )
 
 var (
@@ -59,9 +59,9 @@ func buildConfiguration(tempo v1alpha1.Microservices, params Params) ([]byte, er
 		S3:              s3FromParams(params),
 		GlobalRetention: tempo.Spec.Retention.Global.Traces.String(),
 		MemberList: []string{
-			manifestutils.Name("gossip-ring", tempo.Name),
+			naming.Name("gossip-ring", tempo.Name),
 		},
-		QueryFrontendDiscovery: fmt.Sprintf("%s:9095", manifestutils.Name("query-frontend-discovery", tempo.Name)),
+		QueryFrontendDiscovery: fmt.Sprintf("%s:9095", naming.Name("query-frontend-discovery", tempo.Name)),
 		GlobalRateLimits:       fromRateLimitSpecToRateLimitOptions(tempo.Spec.LimitSpec.Global),
 	}
 

--- a/internal/manifests/config/configmap.go
+++ b/internal/manifests/config/configmap.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
+	"github.com/os-observability/tempo-operator/internal/manifests/naming"
 )
 
 const tenantOverridesMountPath = "/conf/overrides.yaml"
@@ -35,7 +36,7 @@ func BuildConfigMap(tempo v1alpha1.Microservices, params Params) (*corev1.Config
 	labels := manifestutils.ComponentLabels("config", tempo.Name)
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   manifestutils.Name("", tempo.Name),
+			Name:   naming.Name("", tempo.Name),
 			Labels: labels,
 		},
 		Data: map[string]string{

--- a/internal/manifests/distributor/distributor.go
+++ b/internal/manifests/distributor/distributor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
+	"github.com/os-observability/tempo-operator/internal/manifests/serviceaccount"
 )
 
 const (
@@ -50,8 +51,9 @@ func deployment(tempo v1alpha1.Microservices) *v1.Deployment {
 					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: cfg.NodeSelector,
-					Tolerations:  cfg.Tolerations,
+					ServiceAccountName: serviceaccount.ServiceAccountName(tempo),
+					NodeSelector:       cfg.NodeSelector,
+					Tolerations:        cfg.Tolerations,
 					Containers: []corev1.Container{
 						{
 							Name:  "tempo",

--- a/internal/manifests/distributor/distributor.go
+++ b/internal/manifests/distributor/distributor.go
@@ -11,7 +11,7 @@ import (
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
-	"github.com/os-observability/tempo-operator/internal/manifests/serviceaccount"
+	"github.com/os-observability/tempo-operator/internal/manifests/naming"
 )
 
 const (
@@ -38,7 +38,7 @@ func deployment(tempo v1alpha1.Microservices) *v1.Deployment {
 			APIVersion: v1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, tempo.Name),
+			Name:      naming.Name(componentName, tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},
@@ -51,7 +51,7 @@ func deployment(tempo v1alpha1.Microservices) *v1.Deployment {
 					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: serviceaccount.ServiceAccountName(tempo),
+					ServiceAccountName: tempo.Spec.ServiceAccount,
 					NodeSelector:       cfg.NodeSelector,
 					Tolerations:        cfg.Tolerations,
 					Containers: []corev1.Container{
@@ -87,7 +87,7 @@ func deployment(tempo v1alpha1.Microservices) *v1.Deployment {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: manifestutils.Name("", tempo.Name),
+										Name: naming.Name("", tempo.Name),
 									},
 								},
 							},
@@ -103,7 +103,7 @@ func service(tempo v1alpha1.Microservices) *corev1.Service {
 	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, tempo.Name),
+			Name:      naming.Name(componentName, tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},

--- a/internal/manifests/distributor/distributor_test.go
+++ b/internal/manifests/distributor/distributor_test.go
@@ -25,6 +25,7 @@ func TestBuildDistributor(t *testing.T) {
 			Images: v1alpha1.ImagesSpec{
 				Tempo: "docker.io/grafana/tempo:1.5.0",
 			},
+			ServiceAccount: "tempo-test-serviceaccount",
 			Components: v1alpha1.TempoComponentsSpec{
 				Distributor: &v1alpha1.TempoComponentSpec{
 					NodeSelector: map[string]string{"a": "b"},

--- a/internal/manifests/distributor/distributor_test.go
+++ b/internal/manifests/distributor/distributor_test.go
@@ -66,7 +66,8 @@ func TestBuildDistributor(t *testing.T) {
 					Labels: k8slabels.Merge(labels, map[string]string{"tempo-gossip-member": "true"}),
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{"a": "b"},
+					ServiceAccountName: "tempo-test-serviceaccount",
+					NodeSelector:       map[string]string{"a": "b"},
 					Tolerations: []corev1.Toleration{
 						{
 							Key: "c",

--- a/internal/manifests/ingester/ingester.go
+++ b/internal/manifests/ingester/ingester.go
@@ -11,6 +11,7 @@ import (
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	manifestutils "github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
+	"github.com/os-observability/tempo-operator/internal/manifests/serviceaccount"
 )
 
 const (
@@ -54,8 +55,9 @@ func statefulSet(tempo v1alpha1.Microservices) (*v1.StatefulSet, error) {
 					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: cfg.NodeSelector,
-					Tolerations:  cfg.Tolerations,
+					ServiceAccountName: serviceaccount.ServiceAccountName(tempo),
+					NodeSelector:       cfg.NodeSelector,
+					Tolerations:        cfg.Tolerations,
 					Containers: []corev1.Container{
 						{
 							Name:  "tempo",

--- a/internal/manifests/ingester/ingester.go
+++ b/internal/manifests/ingester/ingester.go
@@ -9,9 +9,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
-	manifestutils "github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
+	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
-	"github.com/os-observability/tempo-operator/internal/manifests/serviceaccount"
+	"github.com/os-observability/tempo-operator/internal/manifests/naming"
 )
 
 const (
@@ -42,7 +42,7 @@ func statefulSet(tempo v1alpha1.Microservices) (*v1.StatefulSet, error) {
 
 	ss := &v1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, tempo.Name),
+			Name:      naming.Name(componentName, tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},
@@ -55,7 +55,7 @@ func statefulSet(tempo v1alpha1.Microservices) (*v1.StatefulSet, error) {
 					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: serviceaccount.ServiceAccountName(tempo),
+					ServiceAccountName: tempo.Spec.ServiceAccount,
 					NodeSelector:       cfg.NodeSelector,
 					Tolerations:        cfg.Tolerations,
 					Containers: []corev1.Container{
@@ -100,7 +100,7 @@ func statefulSet(tempo v1alpha1.Microservices) (*v1.StatefulSet, error) {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: manifestutils.Name("", tempo.Name),
+										Name: naming.Name("", tempo.Name),
 									},
 								},
 							},
@@ -138,7 +138,7 @@ func service(tempo v1alpha1.Microservices) *corev1.Service {
 	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, tempo.Name),
+			Name:      naming.Name(componentName, tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},

--- a/internal/manifests/ingester/ingester_test.go
+++ b/internal/manifests/ingester/ingester_test.go
@@ -28,6 +28,7 @@ func TestBuildIngester(t *testing.T) {
 			Images: v1alpha1.ImagesSpec{
 				Tempo: "docker.io/grafana/tempo:1.5.0",
 			},
+			ServiceAccount: "tempo-test-serviceaccount",
 			Storage: v1alpha1.ObjectStorageSpec{
 				Secret: "test-storage-secret",
 			},

--- a/internal/manifests/ingester/ingester_test.go
+++ b/internal/manifests/ingester/ingester_test.go
@@ -72,7 +72,8 @@ func TestBuildIngester(t *testing.T) {
 					Labels: k8slabels.Merge(labels, map[string]string{"tempo-gossip-member": "true"}),
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{"a": "b"},
+					ServiceAccountName: "tempo-test-serviceaccount",
+					NodeSelector:       map[string]string{"a": "b"},
 					Tolerations: []corev1.Toleration{
 						{
 							Key: "c",

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -9,6 +9,7 @@ import (
 	"github.com/os-observability/tempo-operator/internal/manifests/distributor"
 	"github.com/os-observability/tempo-operator/internal/manifests/ingester"
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
+	"github.com/os-observability/tempo-operator/internal/manifests/naming"
 	"github.com/os-observability/tempo-operator/internal/manifests/querier"
 	"github.com/os-observability/tempo-operator/internal/manifests/queryfrontend"
 	"github.com/os-observability/tempo-operator/internal/manifests/serviceaccount"
@@ -62,7 +63,7 @@ func BuildAll(params Params) ([]client.Object, error) {
 
 	var manifests []client.Object
 	manifests = append(manifests, configMaps)
-	if params.Tempo.Spec.ServiceAccount == "" {
+	if params.Tempo.Spec.ServiceAccount == naming.DefaultServiceAccountName(params.Tempo.Name) {
 		manifests = append(manifests, serviceaccount.BuildDefaultServiceAccount(params.Tempo))
 	}
 	manifests = append(manifests, distributor.BuildDistributor(params.Tempo)...)

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -11,6 +11,7 @@ import (
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
 	"github.com/os-observability/tempo-operator/internal/manifests/querier"
 	"github.com/os-observability/tempo-operator/internal/manifests/queryfrontend"
+	"github.com/os-observability/tempo-operator/internal/manifests/serviceaccount"
 )
 
 // Params holds parameters used to create Tempo objects.
@@ -61,6 +62,9 @@ func BuildAll(params Params) ([]client.Object, error) {
 
 	var manifests []client.Object
 	manifests = append(manifests, configMaps)
+	if params.Tempo.Spec.ServiceAccount == "" {
+		manifests = append(manifests, serviceaccount.BuildDefaultServiceAccount(params.Tempo))
+	}
 	manifests = append(manifests, distributor.BuildDistributor(params.Tempo)...)
 	manifests = append(manifests, ingesterObjs...)
 	manifests = append(manifests, memberlist.BuildGossip(params.Tempo))

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -18,5 +18,5 @@ func TestBuildAll(t *testing.T) {
 		},
 	}})
 	require.NoError(t, err)
-	assert.Len(t, objects, 14)
+	assert.Len(t, objects, 13)
 }

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -18,5 +18,5 @@ func TestBuildAll(t *testing.T) {
 		},
 	}})
 	require.NoError(t, err)
-	assert.Len(t, objects, 13)
+	assert.Len(t, objects, 14)
 }

--- a/internal/manifests/manifestutils/labels.go
+++ b/internal/manifests/manifestutils/labels.go
@@ -1,18 +1,8 @@
 package manifestutils
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/labels"
 )
-
-// Name returns component name.
-func Name(component string, instanceName string) string {
-	if component == "" {
-		return fmt.Sprintf("tempo-%s", instanceName)
-	}
-	return fmt.Sprintf("tempo-%s-%s", instanceName, component)
-}
 
 // ComponentLabels is a list of all commonLabels including the app.kubernetes.io/component:<component> label.
 func ComponentLabels(component, instanceName string) labels.Set {

--- a/internal/manifests/memberlist/gossip.go
+++ b/internal/manifests/memberlist/gossip.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
+	"github.com/os-observability/tempo-operator/internal/manifests/naming"
 )
 
 const (
@@ -26,7 +27,7 @@ func BuildGossip(tempo v1alpha1.Microservices) *corev1.Service {
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, tempo.Name),
+			Name:      naming.Name(componentName, tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},

--- a/internal/manifests/naming/naming.go
+++ b/internal/manifests/naming/naming.go
@@ -1,0 +1,18 @@
+package naming
+
+import (
+	"fmt"
+)
+
+// Name returns component name.
+func Name(component string, instanceName string) string {
+	if component == "" {
+		return fmt.Sprintf("tempo-%s", instanceName)
+	}
+	return fmt.Sprintf("tempo-%s-%s", instanceName, component)
+}
+
+// DefaultServiceAccountName returns the name of the default tempo service account to use.
+func DefaultServiceAccountName(name string) string {
+	return Name("serviceaccount", name)
+}

--- a/internal/manifests/naming/naming_test.go
+++ b/internal/manifests/naming/naming_test.go
@@ -1,4 +1,4 @@
-package manifestutils
+package naming
 
 import (
 	"testing"
@@ -27,4 +27,9 @@ func TestName(t *testing.T) {
 			assert.Equal(t, test.expected, got)
 		})
 	}
+}
+
+func TestDefaultServiceAccountName(t *testing.T) {
+	serviceAccountName := DefaultServiceAccountName("test")
+	assert.Equal(t, "tempo-test-serviceaccount", serviceAccountName)
 }

--- a/internal/manifests/querier/querier.go
+++ b/internal/manifests/querier/querier.go
@@ -11,7 +11,7 @@ import (
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
-	"github.com/os-observability/tempo-operator/internal/manifests/serviceaccount"
+	"github.com/os-observability/tempo-operator/internal/manifests/naming"
 )
 
 const (
@@ -45,7 +45,7 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 			APIVersion: v1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, tempo.Name),
+			Name:      naming.Name(componentName, tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},
@@ -58,7 +58,7 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: serviceaccount.ServiceAccountName(tempo),
+					ServiceAccountName: tempo.Spec.ServiceAccount,
 					NodeSelector:       cfg.NodeSelector,
 					Tolerations:        cfg.Tolerations,
 					Containers: []corev1.Container{
@@ -94,7 +94,7 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: manifestutils.Name("", tempo.Name),
+										Name: naming.Name("", tempo.Name),
 									},
 								},
 							},
@@ -116,7 +116,7 @@ func service(tempo v1alpha1.Microservices) *corev1.Service {
 	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, tempo.Name),
+			Name:      naming.Name(componentName, tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},

--- a/internal/manifests/querier/querier.go
+++ b/internal/manifests/querier/querier.go
@@ -11,6 +11,7 @@ import (
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
+	"github.com/os-observability/tempo-operator/internal/manifests/serviceaccount"
 )
 
 const (
@@ -57,8 +58,9 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: cfg.NodeSelector,
-					Tolerations:  cfg.Tolerations,
+					ServiceAccountName: serviceaccount.ServiceAccountName(tempo),
+					NodeSelector:       cfg.NodeSelector,
+					Tolerations:        cfg.Tolerations,
 					Containers: []corev1.Container{
 						{
 							Name:  "tempo",

--- a/internal/manifests/querier/querier_test.go
+++ b/internal/manifests/querier/querier_test.go
@@ -27,6 +27,7 @@ func TestBuildQuerier(t *testing.T) {
 			Images: v1alpha1.ImagesSpec{
 				Tempo: "docker.io/grafana/tempo:1.5.0",
 			},
+			ServiceAccount: "tempo-test-serviceaccount",
 			Components: v1alpha1.TempoComponentsSpec{
 				Querier: &v1alpha1.TempoComponentSpec{
 					NodeSelector: map[string]string{"a": "b"},

--- a/internal/manifests/querier/querier_test.go
+++ b/internal/manifests/querier/querier_test.go
@@ -95,7 +95,8 @@ func TestBuildQuerier(t *testing.T) {
 					Labels: k8slabels.Merge(labels, map[string]string{"tempo-gossip-member": "true"}),
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{"a": "b"},
+					ServiceAccountName: "tempo-test-serviceaccount",
+					NodeSelector:       map[string]string{"a": "b"},
 					Tolerations: []corev1.Toleration{
 						{
 							Key: "c",

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -12,7 +12,7 @@ import (
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
-	"github.com/os-observability/tempo-operator/internal/manifests/serviceaccount"
+	"github.com/os-observability/tempo-operator/internal/manifests/naming"
 )
 
 const (
@@ -61,7 +61,7 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 			APIVersion: v1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, tempo.Name),
+			Name:      naming.Name(componentName, tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},
@@ -74,7 +74,7 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: serviceaccount.ServiceAccountName(tempo),
+					ServiceAccountName: tempo.Spec.ServiceAccount,
 					NodeSelector:       cfg.NodeSelector,
 					Tolerations:        cfg.Tolerations,
 					Affinity: &corev1.Affinity{
@@ -141,7 +141,7 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: manifestutils.Name("", tempo.Name),
+										Name: naming.Name("", tempo.Name),
 									},
 								},
 							},
@@ -215,7 +215,7 @@ func services(tempo v1alpha1.Microservices) []*corev1.Service {
 
 	frontEndService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, tempo.Name),
+			Name:      naming.Name(componentName, tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},
@@ -239,7 +239,7 @@ func services(tempo v1alpha1.Microservices) []*corev1.Service {
 
 	frontEndDiscoveryService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName+"-discovery", tempo.Name),
+			Name:      naming.Name(componentName+"-discovery", tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -12,6 +12,7 @@ import (
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
+	"github.com/os-observability/tempo-operator/internal/manifests/serviceaccount"
 )
 
 const (
@@ -73,8 +74,9 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: cfg.NodeSelector,
-					Tolerations:  cfg.Tolerations,
+					ServiceAccountName: serviceaccount.ServiceAccountName(tempo),
+					NodeSelector:       cfg.NodeSelector,
+					Tolerations:        cfg.Tolerations,
 					Affinity: &corev1.Affinity{
 						PodAntiAffinity: &corev1.PodAntiAffinity{
 							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{

--- a/internal/manifests/queryfrontend/query_frontend_test.go
+++ b/internal/manifests/queryfrontend/query_frontend_test.go
@@ -125,6 +125,7 @@ func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: "tempo-test-serviceaccount",
 					Affinity: &corev1.Affinity{
 						PodAntiAffinity: &corev1.PodAntiAffinity{
 							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{

--- a/internal/manifests/queryfrontend/query_frontend_test.go
+++ b/internal/manifests/queryfrontend/query_frontend_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	"github.com/os-observability/tempo-operator/internal/manifests/memberlist"
+	"github.com/os-observability/tempo-operator/internal/manifests/naming"
 )
 
 func getJaegerServicePorts() []corev1.ServicePort {
@@ -37,7 +38,7 @@ func getExpectedFrontEndService(withJaeger bool) *corev1.Service {
 	labels := manifestutils.ComponentLabels("query-frontend", "test")
 	expectedFrontEndService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, "test"),
+			Name:      naming.Name(componentName, "test"),
 			Namespace: "project1",
 			Labels:    labels,
 		},
@@ -70,7 +71,7 @@ func getExpectedFrontendDiscoveryService(withJaeger bool) *corev1.Service {
 
 	expectedFrontendDiscoveryService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName+"-discovery", "test"),
+			Name:      naming.Name(componentName+"-discovery", "test"),
 			Namespace: "project1",
 			Labels:    labels,
 		},
@@ -112,7 +113,7 @@ func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 			APIVersion: v1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, "test"),
+			Name:      naming.Name(componentName, "test"),
 			Namespace: "project1",
 			Labels:    labels,
 		},
@@ -199,7 +200,7 @@ func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: manifestutils.Name("", "test"),
+										Name: naming.Name("", "test"),
 									},
 								},
 							},
@@ -286,6 +287,7 @@ func TestBuildQueryFrontend(t *testing.T) {
 			Images: v1alpha1.ImagesSpec{
 				Tempo: "docker.io/grafana/tempo:1.5.0",
 			},
+			ServiceAccount: "tempo-test-serviceaccount",
 			Resources: v1alpha1.Resources{
 				Total: &corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -324,6 +326,7 @@ func TestBuildQueryFrontendWithJaeger(t *testing.T) {
 				Tempo:      "docker.io/grafana/tempo:1.5.0",
 				TempoQuery: "docker.io/grafana/tempo-query:1.5.0",
 			},
+			ServiceAccount: "tempo-test-serviceaccount",
 			Components: v1alpha1.TempoComponentsSpec{
 				QueryFrontend: &v1alpha1.TempoQueryFrontendSpec{
 					TempoComponentSpec: v1alpha1.TempoComponentSpec{

--- a/internal/manifests/serviceaccount/serviceaccount.go
+++ b/internal/manifests/serviceaccount/serviceaccount.go
@@ -6,26 +6,19 @@ import (
 
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
+	"github.com/os-observability/tempo-operator/internal/manifests/naming"
 )
 
 const (
 	componentName = "serviceaccount"
 )
 
-// ServiceAccountName returns the name of the custom service account (if specified in the CR) or the default tempo service account to use.
-func ServiceAccountName(tempo v1alpha1.Microservices) string {
-	if tempo.Spec.ServiceAccount != "" {
-		return tempo.Spec.ServiceAccount
-	}
-	return manifestutils.Name(componentName, tempo.Name)
-}
-
 // BuildServiceAccount creates a Kubernetes service account for tempo.
 func BuildDefaultServiceAccount(tempo v1alpha1.Microservices) *corev1.ServiceAccount {
 	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifestutils.Name(componentName, tempo.Name),
+			Name:      naming.DefaultServiceAccountName(tempo.Name),
 			Namespace: tempo.Namespace,
 			Labels:    labels,
 		},

--- a/internal/manifests/serviceaccount/serviceaccount.go
+++ b/internal/manifests/serviceaccount/serviceaccount.go
@@ -1,0 +1,32 @@
+package serviceaccount
+
+import (
+	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
+	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	componentName = "serviceaccount"
+)
+
+// ServiceAccountName returns the name of the custom service account (if specified in the CR) or the default tempo service account to use.
+func ServiceAccountName(tempo v1alpha1.Microservices) string {
+	if tempo.Spec.ServiceAccount != "" {
+		return tempo.Spec.ServiceAccount
+	}
+	return manifestutils.Name(componentName, tempo.Name)
+}
+
+// BuildServiceAccount creates a Kubernetes service account for tempo.
+func BuildDefaultServiceAccount(tempo v1alpha1.Microservices) *corev1.ServiceAccount {
+	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      manifestutils.Name(componentName, tempo.Name),
+			Namespace: tempo.Namespace,
+			Labels:    labels,
+		},
+	}
+}

--- a/internal/manifests/serviceaccount/serviceaccount.go
+++ b/internal/manifests/serviceaccount/serviceaccount.go
@@ -1,10 +1,11 @@
 package serviceaccount
 
 import (
-	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
-	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
+	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 )
 
 const (

--- a/internal/manifests/serviceaccount/serviceaccount_test.go
+++ b/internal/manifests/serviceaccount/serviceaccount_test.go
@@ -30,24 +30,3 @@ func TestBuildDefaultServiceAccount(t *testing.T) {
 		},
 	}, serviceAccount)
 }
-
-func TestServiceAccountName(t *testing.T) {
-	serviceAccountName1 := ServiceAccountName(v1alpha1.Microservices{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "ns1",
-		},
-	})
-	assert.Equal(t, "tempo-test-serviceaccount", serviceAccountName1)
-
-	serviceAccountName2 := ServiceAccountName(v1alpha1.Microservices{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "ns1",
-		},
-		Spec: v1alpha1.MicroservicesSpec{
-			ServiceAccount: "existing-sa",
-		},
-	})
-	assert.Equal(t, "existing-sa", serviceAccountName2)
-}

--- a/internal/manifests/serviceaccount/serviceaccount_test.go
+++ b/internal/manifests/serviceaccount/serviceaccount_test.go
@@ -1,0 +1,53 @@
+package serviceaccount
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
+	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
+)
+
+func TestBuildDefaultServiceAccount(t *testing.T) {
+	serviceAccount := BuildDefaultServiceAccount(v1alpha1.Microservices{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "ns1",
+		},
+	})
+
+	labels := manifestutils.ComponentLabels("serviceaccount", "test")
+	require.NotNil(t, serviceAccount)
+	assert.Equal(t, &v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tempo-test-serviceaccount",
+			Namespace: "ns1",
+			Labels:    labels,
+		},
+	}, serviceAccount)
+}
+
+func TestServiceAccountName(t *testing.T) {
+	serviceAccountName1 := ServiceAccountName(v1alpha1.Microservices{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "ns1",
+		},
+	})
+	assert.Equal(t, "tempo-test-serviceaccount", serviceAccountName1)
+
+	serviceAccountName2 := ServiceAccountName(v1alpha1.Microservices{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "ns1",
+		},
+		Spec: v1alpha1.MicroservicesSpec{
+			ServiceAccount: "existing-sa",
+		},
+	})
+	assert.Equal(t, "existing-sa", serviceAccountName2)
+}

--- a/tests/e2e/smoketest-with-jaeger/01-assert.yaml
+++ b/tests/e2e/smoketest-with-jaeger/01-assert.yaml
@@ -3,6 +3,20 @@ kind: Microservices
 metadata:
   name: simplest
 #
+# Service Accounts
+#
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tempo-simplest-serviceaccount
+  labels:
+    app.kubernetes.io/component: serviceaccount
+    app.kubernetes.io/created-by: tempo-controller
+    app.kubernetes.io/instance: simplest
+    app.kubernetes.io/managed-by: tempo-controller
+    app.kubernetes.io/name: tempo
+#
 # Deployments
 #
 ---


### PR DESCRIPTION
Use a service account for all components:
* serviceAccount can be specified in the CR
* if specified in the CR, it will get validated in the validator webhook
* if not specified in the CR, the operator creates a default SA

Current (afaics unrelated) issues:
* the PodAntiAffinity rule of the query-frontend pod prevents the deployment from adding a new pod (and terminating the old one) during reconciling if the cluster only has a single node: `Warning  FailedScheduling  22s (x11 over 20m)  default-scheduler  0/1 nodes are available: 1 node(s) didn't match pod anti-affinity rules. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.`

Resolves: #101