### PR TITLE
Validate storage secret

### DIFF
--- a/apis/tempo/v1alpha1/microservices_types.go
+++ b/apis/tempo/v1alpha1/microservices_types.go
@@ -142,7 +142,7 @@ type ObjectStorageSpec struct {
 	// Name of a secret in the same namespace as the tempo Microservices custom resource.
 	//
 	// +optional
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Object Storage Secret"
 	Secret string `json:"secret,omitempty"`
 }

--- a/apis/tempo/v1alpha1/microservices_webhook.go
+++ b/apis/tempo/v1alpha1/microservices_webhook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -122,6 +123,58 @@ func (v *validator) validateServiceAccount(ctx context.Context, tempo *Microserv
 	return allErrs
 }
 
+func (v *validator) validateStorageSecret(tempo *Microservices, storageSecret *corev1.Secret) field.ErrorList {
+	path := field.NewPath("spec").Child("storage").Child("secret")
+
+	if storageSecret.Data == nil {
+		return field.ErrorList{field.Invalid(path, tempo.Spec.Storage.Secret, "storage secret is empty")}
+	}
+
+	var allErrs field.ErrorList
+	for _, key := range []string{
+		"endpoint",
+		"bucket",
+		"access_key_id",
+		"access_key_secret",
+	} {
+		if storageSecret.Data[key] == nil || len(storageSecret.Data[key]) == 0 {
+			allErrs = append(allErrs, field.Invalid(
+				path,
+				tempo.Spec.Storage.Secret,
+				fmt.Sprintf("storage secret must contain \"%s\" field", key),
+			))
+		} else if key == "endpoint" {
+			u, err := url.ParseRequestURI(string(storageSecret.Data["endpoint"]))
+
+			// ParseRequestURI also accepts absolute paths, therefore we need to check if the URL scheme is set
+			if err != nil || u.Scheme == "" {
+				allErrs = append(allErrs, field.Invalid(
+					path,
+					tempo.Spec.Storage.Secret,
+					"\"endpoint\" field of storage secret must be a valid URL",
+				))
+			}
+		}
+	}
+	return allErrs
+}
+
+func (v *validator) validateStorage(ctx context.Context, tempo *Microservices) field.ErrorList {
+	path := field.NewPath("spec").Child("storage").Child("secret")
+
+	if tempo.Spec.Storage.Secret == "" {
+		return field.ErrorList{field.Invalid(path, tempo.Spec.Storage.Secret, "storage secret is required")}
+	}
+
+	storageSecret := &corev1.Secret{}
+	err := v.client.Get(ctx, types.NamespacedName{Namespace: tempo.Namespace, Name: tempo.Spec.Storage.Secret}, storageSecret)
+	if err != nil {
+		return field.ErrorList{field.Invalid(path, tempo.Spec.Storage.Secret, err.Error())}
+	}
+
+	return v.validateStorageSecret(tempo, storageSecret)
+}
+
 func (v *validator) validate(ctx context.Context, obj runtime.Object) error {
 	tempo, ok := obj.(*Microservices)
 	if !ok {
@@ -131,6 +184,7 @@ func (v *validator) validate(ctx context.Context, obj runtime.Object) error {
 
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, v.validateServiceAccount(ctx, tempo)...)
+	allErrs = append(allErrs, v.validateStorage(ctx, tempo)...)
 	if len(allErrs) == 0 {
 		return nil
 	}

--- a/apis/tempo/v1alpha1/microservices_webhook_test.go
+++ b/apis/tempo/v1alpha1/microservices_webhook_test.go
@@ -6,8 +6,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func TestDefault(t *testing.T) {
@@ -117,6 +119,93 @@ func TestDefault(t *testing.T) {
 			err := defaulter.Default(context.Background(), test.input)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expected, test.input)
+		})
+	}
+}
+
+func TestValidateStorageSecret(t *testing.T) {
+	tempo := &Microservices{
+		Spec: MicroservicesSpec{
+			Storage: ObjectStorageSpec{
+				Secret: "testsecret",
+			},
+		},
+	}
+	validator := &validator{}
+	path := field.NewPath("spec").Child("storage").Child("secret")
+
+	tests := []struct {
+		name     string
+		input    *corev1.Secret
+		expected field.ErrorList
+	}{
+		{
+			name:  "empty secret",
+			input: &corev1.Secret{},
+			expected: field.ErrorList{
+				field.Invalid(path, tempo.Spec.Storage.Secret, "storage secret is empty"),
+			},
+		},
+		{
+			name: "missing or empty fields",
+			input: &corev1.Secret{
+				Data: map[string][]byte{
+					"bucket": []byte(""),
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(path, tempo.Spec.Storage.Secret, "storage secret must contain \"endpoint\" field"),
+				field.Invalid(path, tempo.Spec.Storage.Secret, "storage secret must contain \"bucket\" field"),
+				field.Invalid(path, tempo.Spec.Storage.Secret, "storage secret must contain \"access_key_id\" field"),
+				field.Invalid(path, tempo.Spec.Storage.Secret, "storage secret must contain \"access_key_secret\" field"),
+			},
+		},
+		{
+			name: "invalid endpoint 'invalid'",
+			input: &corev1.Secret{
+				Data: map[string][]byte{
+					"endpoint":          []byte("invalid"),
+					"bucket":            []byte("bucket"),
+					"access_key_id":     []byte("id"),
+					"access_key_secret": []byte("secret"),
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(path, tempo.Spec.Storage.Secret, "\"endpoint\" field of storage secret must be a valid URL"),
+			},
+		},
+		{
+			name: "invalid endpoint '/invalid'",
+			input: &corev1.Secret{
+				Data: map[string][]byte{
+					"endpoint":          []byte("/invalid"),
+					"bucket":            []byte("bucket"),
+					"access_key_id":     []byte("id"),
+					"access_key_secret": []byte("secret"),
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(path, tempo.Spec.Storage.Secret, "\"endpoint\" field of storage secret must be a valid URL"),
+			},
+		},
+		{
+			name: "valid storage secret",
+			input: &corev1.Secret{
+				Data: map[string][]byte{
+					"endpoint":          []byte("http://minio.minio.svc:9000"),
+					"bucket":            []byte("bucket"),
+					"access_key_id":     []byte("id"),
+					"access_key_secret": []byte("secret"),
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			errs := validator.validateStorageSecret(tempo, test.input)
+			assert.Equal(t, test.expected, errs)
 		})
 	}
 }

--- a/controllers/tempo/microservices_controller.go
+++ b/controllers/tempo/microservices_controller.go
@@ -111,7 +111,6 @@ func (r *MicroservicesReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 func (r *MicroservicesReconciler) getStorageConfig(ctx context.Context, tempo v1alpha1.Microservices) (*manifests.StorageParams, error) {
 	storageSecret := &corev1.Secret{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: tempo.Namespace, Name: tempo.Spec.Storage.Secret}, storageSecret)
-	// TODO check if secret exists in the validating webhook
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch storage secret: %w", err)
 	}


### PR DESCRIPTION
* checks if the secret name is set and refers to an existing secret
* checks if the secret content is empty
* checks if all required fields are set in the secret
* checks if the endpoint is a valid URL

The branch of this PR is based on #124 because it also requires the custom validator.
Resolves: #58