### PR TITLE
Deploy minio before kuttl e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,7 @@ e2e:
 	$(KUTTL) test
 
 .PHONY: prepare-e2e
-prepare-e2e: kuttl start-kind cert-manager set-test-image-vars docker-build load-image-operator deploy
+prepare-e2e: kuttl start-kind cert-manager deploy-minio set-test-image-vars docker-build load-image-operator deploy
 
 .PHONY: set-test-image-vars
 set-test-image-vars:

--- a/tests/e2e/reconcile/00-install-minio.yaml
+++ b/tests/e2e/reconcile/00-install-minio.yaml
@@ -1,4 +1,0 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: "cd ../../../ && make deploy-minio"

--- a/tests/e2e/smoketest-with-jaeger/00-install-minio.yaml
+++ b/tests/e2e/smoketest-with-jaeger/00-install-minio.yaml
@@ -1,4 +1,0 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: "cd ../../../ && make deploy-minio"


### PR DESCRIPTION
Kuttl runs both e2e tests in parallel, and if `kubectl apply -f minio.yaml` is executed simultaneously, it will likely fail with `error when creating "minio.yaml": ... already exists`.

Steps to reproduce race condition:
```
# in case minio is already deployed
kubectl delete -f minio.yaml

# fails usually
kubectl apply -f minio.yaml & kubectl apply -f minio.yaml

# works (commands are executed serially)
kubectl apply -f minio.yaml ; kubectl apply -f minio.yaml
```