### PR TITLE
Watch storage secret and reconcile on changes

### DIFF
--- a/apis/tempo/v1alpha1/microservices_types.go
+++ b/apis/tempo/v1alpha1/microservices_types.go
@@ -178,6 +178,7 @@ type ObjectStorageSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Object Storage Secret"
 	Secret string `json:"secret"`
+	// Don't forget to update storageSecretField in microservices_controller.go if this field name changes.
 }
 
 // ObjectStorageTLSSpec is the TLS configuration for reaching the object storage endpoint.

--- a/controllers/tempo/microservices_controller.go
+++ b/controllers/tempo/microservices_controller.go
@@ -143,7 +143,7 @@ func (r *MicroservicesReconciler) getStorageConfig(ctx context.Context, tempo v1
 // SetupWithManager sets up the controller with the Manager.
 func (r *MicroservicesReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Add an index to the storage secret field in the Microservices CRD.
-	// If the content of any secret changes, the watcher can identify related Microservices CRs
+	// If the content of any secret in the cluster changes, the watcher can identify related Microservices CRs
 	// and reconcile them (i.e. update the tempo configuration file and restart the pods)
 	err := mgr.GetFieldIndexer().IndexField(context.Background(), &v1alpha1.Microservices{}, storageSecretField, func(rawObj client.Object) []string {
 		microservices := rawObj.(*v1alpha1.Microservices)

--- a/tests/e2e/reconcile/03-update-storage-secret.yaml
+++ b/tests/e2e/reconcile/03-update-storage-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+   name: minio-test
+stringData:
+  bucket: tempo-updated
+type: Opaque

--- a/tests/e2e/reconcile/04-check-bucket-name.yaml
+++ b/tests/e2e/reconcile/04-check-bucket-name.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # workaround for asserting parts of the configmap
+  # can be removed once https://github.com/kudobuilder/kuttl/issues/262 is implemented
+  - command: "/bin/sh -c 'kubectl get --namespace $NAMESPACE configmap tempo-simplest -o yaml | grep \"bucket: tempo-updated\"'"
+    namespaced: true


### PR DESCRIPTION
The tempo configuration file (ConfigMap) needs to be updated if the content of the storage secret changes.

Resolves: #133
Signed-off-by: Andreas Gerstmayr <agerstmayr@redhat.com>