### PR TITLE
Restart pods when the tempo configuration changes

### DIFF
--- a/controllers/tempo/microservices_controller.go
+++ b/controllers/tempo/microservices_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
 	"github.com/os-observability/tempo-operator/internal/manifests"
+	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 )
 
 const (
@@ -72,7 +73,7 @@ func (r *MicroservicesReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("storage secret error: %w", err)
 	}
 
-	objects, err := manifests.BuildAll(manifests.Params{Tempo: tempo, StorageParams: *storageConfig})
+	objects, err := manifests.BuildAll(manifestutils.Params{Tempo: tempo, StorageParams: *storageConfig})
 	// TODO (pavolloffay) check error type and change return appropriately
 	if err != nil {
 		return ctrl.Result{
@@ -119,7 +120,7 @@ func (r *MicroservicesReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	return ctrl.Result{}, nil
 }
 
-func (r *MicroservicesReconciler) getStorageConfig(ctx context.Context, tempo v1alpha1.Microservices) (*manifests.StorageParams, error) {
+func (r *MicroservicesReconciler) getStorageConfig(ctx context.Context, tempo v1alpha1.Microservices) (*manifestutils.StorageParams, error) {
 	storageSecret := &corev1.Secret{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: tempo.Namespace, Name: tempo.Spec.Storage.Secret}, storageSecret)
 	if err != nil {
@@ -134,7 +135,7 @@ func (r *MicroservicesReconciler) getStorageConfig(ctx context.Context, tempo v1
 		return nil, fmt.Errorf("storage secret should contain endpoint and bucket, access_key_id and access_key_secret fields")
 	}
 
-	return &manifests.StorageParams{S3: manifests.S3{
+	return &manifestutils.StorageParams{S3: manifestutils.S3{
 		Endpoint: string(storageSecret.Data["endpoint"]),
 		Bucket:   string(storageSecret.Data["bucket"]),
 	}}, nil

--- a/internal/manifests/compactor/compactor_test.go
+++ b/internal/manifests/compactor/compactor_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestBuildCompactor(t *testing.T) {
-	objects, err := BuildCompactor(v1alpha1.Microservices{
+	objects, err := BuildCompactor(manifestutils.Params{Tempo: v1alpha1.Microservices{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "project1",
@@ -46,10 +46,11 @@ func TestBuildCompactor(t *testing.T) {
 				},
 			},
 		},
-	})
+	}})
 	require.NoError(t, err)
 
 	labels := manifestutils.ComponentLabels("compactor", "test")
+	annotations := manifestutils.CommonAnnotations("")
 	assert.Equal(t, 2, len(objects))
 
 	assert.Equal(t, &corev1.Service{
@@ -92,7 +93,8 @@ func TestBuildCompactor(t *testing.T) {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: k8slabels.Merge(labels, map[string]string{"tempo-gossip-member": "true"}),
+					Labels:      k8slabels.Merge(labels, map[string]string{"tempo-gossip-member": "true"}),
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "tempo-test-serviceaccount",

--- a/internal/manifests/config/configmap.go
+++ b/internal/manifests/config/configmap.go
@@ -25,6 +25,9 @@ type S3 struct {
 	Bucket   string
 }
 
+// BuildConfigMap builds the tempo configuration file and the tenant-specific overrides configuration.
+// It returns a ConfigMap containing both configuration files and the checksum of the main configuration file
+// (the tenant-specific configuration gets reloaded automatically, therefore no checksum is required).
 func BuildConfigMap(tempo v1alpha1.Microservices, params Params) (*corev1.ConfigMap, string, error) {
 	config, err := buildConfiguration(tempo, params)
 	if err != nil {

--- a/internal/manifests/config/configmap.go
+++ b/internal/manifests/config/configmap.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"crypto/sha256"
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -22,15 +25,15 @@ type S3 struct {
 	Bucket   string
 }
 
-func BuildConfigMap(tempo v1alpha1.Microservices, params Params) (*corev1.ConfigMap, error) {
+func BuildConfigMap(tempo v1alpha1.Microservices, params Params) (*corev1.ConfigMap, string, error) {
 	config, err := buildConfiguration(tempo, params)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	overridesConfig, err := buildTenantOverrides(tempo)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	labels := manifestutils.ComponentLabels("config", tempo.Name)
@@ -48,5 +51,10 @@ func BuildConfigMap(tempo v1alpha1.Microservices, params Params) (*corev1.Config
 		configMap.Data["tempo-query.yaml"] = "backend: 127.0.0.1:3100\n"
 	}
 
-	return configMap, nil
+	// We only need to hash the main ConfigMap, the per-tenant overrides
+	// is reloaded by tempo without requiring a restart
+	h := sha256.Sum256(config)
+	checksum := fmt.Sprintf("%x", h)
+
+	return configMap, checksum, nil
 }

--- a/internal/manifests/config/configmap_test.go
+++ b/internal/manifests/config/configmap_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"testing"
 	"time"
 
@@ -11,7 +13,7 @@ import (
 )
 
 func TestConfigmap(t *testing.T) {
-	cm, err := BuildConfigMap(v1alpha1.Microservices{
+	cm, checksum, err := BuildConfigMap(v1alpha1.Microservices{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
 		},
@@ -31,5 +33,5 @@ func TestConfigmap(t *testing.T) {
 	require.NotNil(t, cm.Data)
 	require.NotNil(t, cm.Data["tempo.yaml"])
 	require.NotNil(t, cm.Data["overrides.yaml"])
-
+	require.Equal(t, fmt.Sprintf("%x", sha256.Sum256([]byte(cm.Data["tempo.yaml"]))), checksum)
 }

--- a/internal/manifests/distributor/distributor.go
+++ b/internal/manifests/distributor/distributor.go
@@ -19,12 +19,14 @@ const (
 )
 
 // BuildDistributor creates distributor objects.
-func BuildDistributor(tempo v1alpha1.Microservices) []client.Object {
-	return []client.Object{deployment(tempo), service(tempo)}
+func BuildDistributor(params manifestutils.Params) []client.Object {
+	return []client.Object{deployment(params), service(params.Tempo)}
 }
 
-func deployment(tempo v1alpha1.Microservices) *v1.Deployment {
+func deployment(params manifestutils.Params) *v1.Deployment {
+	tempo := params.Tempo
 	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
+	annotations := manifestutils.CommonAnnotations(params.ConfigChecksum)
 	cfg := &v1alpha1.TempoComponentSpec{}
 	if userCfg := tempo.Spec.Components.Distributor; userCfg != nil {
 		cfg = userCfg
@@ -45,7 +47,8 @@ func deployment(tempo v1alpha1.Microservices) *v1.Deployment {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
+					Labels:      k8slabels.Merge(labels, memberlist.GossipSelector),
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: tempo.Spec.ServiceAccount,

--- a/internal/manifests/distributor/distributor_test.go
+++ b/internal/manifests/distributor/distributor_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestBuildDistributor(t *testing.T) {
-	objects := BuildDistributor(v1alpha1.Microservices{
+	objects := BuildDistributor(manifestutils.Params{Tempo: v1alpha1.Microservices{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "project1",
@@ -45,9 +45,10 @@ func TestBuildDistributor(t *testing.T) {
 				},
 			},
 		},
-	})
+	}})
 
 	labels := manifestutils.ComponentLabels("distributor", "test")
+	annotations := manifestutils.CommonAnnotations("")
 	assert.Equal(t, 2, len(objects))
 	assert.Equal(t, &v1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -64,7 +65,8 @@ func TestBuildDistributor(t *testing.T) {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: k8slabels.Merge(labels, map[string]string{"tempo-gossip-member": "true"}),
+					Labels:      k8slabels.Merge(labels, map[string]string{"tempo-gossip-member": "true"}),
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "tempo-test-serviceaccount",

--- a/internal/manifests/ingester/ingester_test.go
+++ b/internal/manifests/ingester/ingester_test.go
@@ -19,7 +19,7 @@ import (
 func TestBuildIngester(t *testing.T) {
 	storageClassName := "default"
 	filesystem := corev1.PersistentVolumeFilesystem
-	objects, err := BuildIngester(v1alpha1.Microservices{
+	objects, err := BuildIngester(manifestutils.Params{Tempo: v1alpha1.Microservices{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "project1",
@@ -53,10 +53,11 @@ func TestBuildIngester(t *testing.T) {
 				},
 			},
 		},
-	})
+	}})
 	require.NoError(t, err)
 
 	labels := manifestutils.ComponentLabels("ingester", "test")
+	annotations := manifestutils.CommonAnnotations("")
 	assert.Equal(t, 2, len(objects))
 	assert.Equal(t, &v1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -70,7 +71,8 @@ func TestBuildIngester(t *testing.T) {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: k8slabels.Merge(labels, map[string]string{"tempo-gossip-member": "true"}),
+					Labels:      k8slabels.Merge(labels, map[string]string{"tempo-gossip-member": "true"}),
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "tempo-test-serviceaccount",

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -8,10 +8,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
+	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 )
 
 func TestBuildAll(t *testing.T) {
-	objects, err := BuildAll(Params{Tempo: v1alpha1.Microservices{
+	objects, err := BuildAll(manifestutils.Params{Tempo: v1alpha1.Microservices{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "project1",

--- a/internal/manifests/manifestutils/annotations.go
+++ b/internal/manifests/manifestutils/annotations.go
@@ -1,0 +1,7 @@
+package manifestutils
+
+func CommonAnnotations(configChecksum string) map[string]string {
+	return map[string]string{
+		"tempo.grafana.com/config.hash": configChecksum,
+	}
+}

--- a/internal/manifests/manifestutils/params.go
+++ b/internal/manifests/manifestutils/params.go
@@ -1,0 +1,22 @@
+package manifestutils
+
+import "github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
+
+// Params holds parameters used to create Tempo objects.
+type Params struct {
+	StorageParams  StorageParams
+	ConfigChecksum string
+
+	Tempo v1alpha1.Microservices
+}
+
+// StorageParams holds storage configuration.
+type StorageParams struct {
+	S3 S3
+}
+
+// S3 holds S3 configuration.
+type S3 struct {
+	Endpoint string
+	Bucket   string
+}

--- a/internal/manifests/querier/querier.go
+++ b/internal/manifests/querier/querier.go
@@ -19,17 +19,19 @@ const (
 )
 
 // BuildQuerier creates querier objects.
-func BuildQuerier(tempo v1alpha1.Microservices) ([]client.Object, error) {
-	d, err := deployment(tempo)
+func BuildQuerier(params manifestutils.Params) ([]client.Object, error) {
+	d, err := deployment(params)
 	if err != nil {
 		return nil, err
 	}
 
-	return []client.Object{d, service(tempo)}, nil
+	return []client.Object{d, service(params.Tempo)}, nil
 }
 
-func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
+func deployment(params manifestutils.Params) (*v1.Deployment, error) {
+	tempo := params.Tempo
 	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
+	annotations := manifestutils.CommonAnnotations(params.ConfigChecksum)
 	cfg := &v1alpha1.TempoComponentSpec{}
 	if userCfg := tempo.Spec.Components.Querier; userCfg != nil {
 		cfg = userCfg
@@ -50,7 +52,8 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
+					Labels:      k8slabels.Merge(labels, memberlist.GossipSelector),
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: tempo.Spec.ServiceAccount,

--- a/internal/manifests/querier/querier_test.go
+++ b/internal/manifests/querier/querier_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestBuildQuerier(t *testing.T) {
-	objects, err := BuildQuerier(v1alpha1.Microservices{
+	objects, err := BuildQuerier(manifestutils.Params{Tempo: v1alpha1.Microservices{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "project1",
@@ -46,10 +46,11 @@ func TestBuildQuerier(t *testing.T) {
 				},
 			},
 		},
-	})
+	}})
 	require.NoError(t, err)
 
 	labels := manifestutils.ComponentLabels("querier", "test")
+	annotations := manifestutils.CommonAnnotations("")
 	assert.Equal(t, 2, len(objects))
 
 	assert.Equal(t, &corev1.Service{
@@ -98,7 +99,8 @@ func TestBuildQuerier(t *testing.T) {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: k8slabels.Merge(labels, map[string]string{"tempo-gossip-member": "true"}),
+					Labels:      k8slabels.Merge(labels, map[string]string{"tempo-gossip-member": "true"}),
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "tempo-test-serviceaccount",

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -28,12 +28,12 @@ const (
 )
 
 // BuildQueryFrontend creates the query-frontend objects.
-func BuildQueryFrontend(tempo v1alpha1.Microservices) ([]client.Object, error) {
-	d, err := deployment(tempo)
+func BuildQueryFrontend(params manifestutils.Params) ([]client.Object, error) {
+	d, err := deployment(params)
 	if err != nil {
 		return nil, err
 	}
-	svcs := services(tempo)
+	svcs := services(params.Tempo)
 
 	var manifests []client.Object
 	manifests = append(manifests, d)
@@ -43,9 +43,10 @@ func BuildQueryFrontend(tempo v1alpha1.Microservices) ([]client.Object, error) {
 	return manifests, nil
 }
 
-func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
+func deployment(params manifestutils.Params) (*v1.Deployment, error) {
+	tempo := params.Tempo
 	labels := manifestutils.ComponentLabels(componentName, tempo.Name)
-
+	annotations := manifestutils.CommonAnnotations(params.ConfigChecksum)
 	cfg := &v1alpha1.TempoComponentSpec{}
 	if userCfg := tempo.Spec.Components.QueryFrontend; userCfg != nil {
 		cfg = &userCfg.TempoComponentSpec
@@ -66,7 +67,8 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
+					Labels:      k8slabels.Merge(labels, memberlist.GossipSelector),
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: tempo.Spec.ServiceAccount,

--- a/internal/manifests/queryfrontend/query_frontend_test.go
+++ b/internal/manifests/queryfrontend/query_frontend_test.go
@@ -107,6 +107,7 @@ func getExpectedFrontendDiscoveryService(withJaeger bool) *corev1.Service {
 
 func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 	labels := manifestutils.ComponentLabels("query-frontend", "test")
+	annotations := manifestutils.CommonAnnotations("")
 
 	expectedDeployment := &v1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -123,7 +124,8 @@ func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: k8slabels.Merge(labels, memberlist.GossipSelector),
+					Labels:      k8slabels.Merge(labels, memberlist.GossipSelector),
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "tempo-test-serviceaccount",
@@ -278,7 +280,7 @@ func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 }
 
 func TestBuildQueryFrontend(t *testing.T) {
-	objects, err := BuildQueryFrontend(v1alpha1.Microservices{
+	objects, err := BuildQueryFrontend(manifestutils.Params{Tempo: v1alpha1.Microservices{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "project1",
@@ -297,7 +299,7 @@ func TestBuildQueryFrontend(t *testing.T) {
 				},
 			},
 		},
-	})
+	}})
 	require.NoError(t, err)
 	require.Equal(t, 3, len(objects))
 
@@ -316,7 +318,7 @@ func TestBuildQueryFrontend(t *testing.T) {
 
 func TestBuildQueryFrontendWithJaeger(t *testing.T) {
 	withJaeger := true
-	objects, err := BuildQueryFrontend(v1alpha1.Microservices{
+	objects, err := BuildQueryFrontend(manifestutils.Params{Tempo: v1alpha1.Microservices{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "project1",
@@ -351,7 +353,7 @@ func TestBuildQueryFrontendWithJaeger(t *testing.T) {
 				},
 			},
 		},
-	})
+	}})
 
 	require.NoError(t, err)
 	require.Equal(t, 3, len(objects))

--- a/tests/e2e/reconcile/03-assert.yaml
+++ b/tests/e2e/reconcile/03-assert.yaml
@@ -1,0 +1,41 @@
+# An update of the storage secret triggers an update of
+# the configuration, which triggers a restart of the pods.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-compactor
+  generation: 2
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-distributor
+  generation: 2
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-simplest-ingester
+  generation: 2
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-querier
+  generation: 2
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-simplest-query-frontend
+  generation: 2
+status:
+  readyReplicas: 1

--- a/tests/e2e/reconcile/03-update-storage-secret.yaml
+++ b/tests/e2e/reconcile/03-update-storage-secret.yaml
@@ -3,5 +3,5 @@ kind: Secret
 metadata:
    name: minio-test
 stringData:
-  bucket: tempo-updated
+  endpoint: http://minio.minio.svc.cluster.local:9000
 type: Opaque

--- a/tests/e2e/reconcile/04-check-bucket-name.yaml
+++ b/tests/e2e/reconcile/04-check-bucket-name.yaml
@@ -3,5 +3,5 @@ kind: TestStep
 commands:
   # workaround for asserting parts of the configmap
   # can be removed once https://github.com/kudobuilder/kuttl/issues/262 is implemented
-  - command: "/bin/sh -c 'kubectl get --namespace $NAMESPACE configmap tempo-simplest -o yaml | grep \"bucket: tempo-updated\"'"
+  - command: "/bin/sh -c 'kubectl get --namespace $NAMESPACE configmap tempo-simplest -o yaml | grep \"endpoint: minio.minio.svc.cluster.local\"'"
     namespaced: true


### PR DESCRIPTION
This change adds the checksum of the tempo configuration file to the PodTemplateSpec of each Deployment and StatefulSet. If the tempo configuration changes, the checksum will be updated, and the Deployments and StatefulSet will trigger a recreation of the pods.
This is required for tempo to load the new configuration.

Resolves: #137
Note: This PR is based on #154 because of the e2e tests, I'll rebase this PR once #154 is merged.