### PR TITLE
Simplify query-frontend service port mappings

### DIFF
--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -16,15 +16,13 @@ import (
 )
 
 const (
-	componentName              = "query-frontend"
-	grpclbPortName             = "grpclb"
-	jaegerMetricsPortName      = "jaeger-metrics"
-	jaegerUIPortName           = "jaeger-ui"
-	tempoQueryJaegerUiPortName = "tempo-query-jaeger-ui"
-	tempoQueryMetricsPortName  = "tempo-query-metrics"
-	portGRPCLBServer           = 9096
-	portJaegerUI               = 16686
-	portQueryMetrics           = 16687
+	componentName         = "query-frontend"
+	grpclbPortName        = "grpclb"
+	jaegerMetricsPortName = "jaeger-metrics"
+	jaegerUIPortName      = "jaeger-ui"
+	portGRPCLBServer      = 9096
+	portJaegerUI          = 16686
+	portJaegerMetrics     = 16687
 )
 
 // BuildQueryFrontend creates the query-frontend objects.
@@ -170,7 +168,7 @@ func deployment(tempo v1alpha1.Microservices) (*v1.Deployment, error) {
 				},
 				{
 					Name:          jaegerMetricsPortName,
-					ContainerPort: portQueryMetrics,
+					ContainerPort: portJaegerMetrics,
 					Protocol:      corev1.ProtocolTCP,
 				},
 			},
@@ -265,14 +263,14 @@ func services(tempo v1alpha1.Microservices) []*corev1.Service {
 	if tempo.Spec.Components.QueryFrontend != nil && tempo.Spec.Components.QueryFrontend.JaegerQuery.Enabled {
 		jaegerPorts := []corev1.ServicePort{
 			{
-				Name:       tempoQueryJaegerUiPortName,
+				Name:       jaegerUIPortName,
 				Port:       portJaegerUI,
-				TargetPort: intstr.FromInt(portJaegerUI),
+				TargetPort: intstr.FromString(jaegerUIPortName),
 			},
 			{
-				Name:       tempoQueryMetricsPortName,
-				Port:       portQueryMetrics,
-				TargetPort: intstr.FromString("jaeger-metrics"),
+				Name:       jaegerMetricsPortName,
+				Port:       portJaegerMetrics,
+				TargetPort: intstr.FromString(jaegerMetricsPortName),
 			},
 		}
 

--- a/internal/manifests/queryfrontend/query_frontend_test.go
+++ b/internal/manifests/queryfrontend/query_frontend_test.go
@@ -21,14 +21,14 @@ import (
 func getJaegerServicePorts() []corev1.ServicePort {
 	jaegerServicePorts := []corev1.ServicePort{
 		{
-			Name:       tempoQueryJaegerUiPortName,
+			Name:       jaegerUIPortName,
 			Port:       portJaegerUI,
-			TargetPort: intstr.FromInt(portJaegerUI),
+			TargetPort: intstr.FromString(jaegerUIPortName),
 		},
 		{
-			Name:       tempoQueryMetricsPortName,
-			Port:       portQueryMetrics,
-			TargetPort: intstr.FromString("jaeger-metrics"),
+			Name:       jaegerMetricsPortName,
+			Port:       portJaegerMetrics,
+			TargetPort: intstr.FromString(jaegerMetricsPortName),
 		},
 	}
 	return jaegerServicePorts
@@ -234,7 +234,7 @@ func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 				},
 				{
 					Name:          jaegerMetricsPortName,
-					ContainerPort: portQueryMetrics,
+					ContainerPort: portJaegerMetrics,
 					Protocol:      corev1.ProtocolTCP,
 				},
 			},

--- a/tests/e2e/smoketest-with-jaeger/01-assert.yaml
+++ b/tests/e2e/smoketest-with-jaeger/01-assert.yaml
@@ -263,11 +263,11 @@ spec:
       port: 9095
       protocol: TCP
       targetPort: grpc
-    - name: tempo-query-jaeger-ui
+    - name: jaeger-ui
       port: 16686
       protocol: TCP
-      targetPort: 16686
-    - name: tempo-query-metrics
+      targetPort: jaeger-ui
+    - name: jaeger-metrics
       port: 16687
       protocol: TCP
       targetPort: jaeger-metrics
@@ -302,11 +302,11 @@ spec:
       port: 9096
       protocol: TCP
       targetPort: grpclb
-    - name: tempo-query-jaeger-ui
+    - name: jaeger-ui
       port: 16686
       protocol: TCP
-      targetPort: 16686
-    - name: tempo-query-metrics
+      targetPort: jaeger-ui
+    - name: jaeger-metrics
       port: 16687
       protocol: TCP
       targetPort: jaeger-metrics


### PR DESCRIPTION
The tempo-query pod port names are "jaeger-ui" and "jaeger-metrics", but the service port mappings were prefixed with tempo-query-*.

This change syncs the service port mapping names with the pod port names, and uses intstr.FromString to have descriptive names in the service configuration (and in UIs like the OpenShift Console).

Signed-off-by: Andreas Gerstmayr <agerstmayr@redhat.com>