### PR TITLE
Update PodAntiAffinity for most components

### DIFF
--- a/internal/manifests/distributor/distributor.go
+++ b/internal/manifests/distributor/distributor.go
@@ -54,6 +54,7 @@ func deployment(params manifestutils.Params) *v1.Deployment {
 					ServiceAccountName: tempo.Spec.ServiceAccount,
 					NodeSelector:       cfg.NodeSelector,
 					Tolerations:        cfg.Tolerations,
+					Affinity:           manifestutils.DefaultAffinity(labels),
 					Containers: []corev1.Container{
 						{
 							Name:  "tempo",

--- a/internal/manifests/distributor/distributor_test.go
+++ b/internal/manifests/distributor/distributor_test.go
@@ -76,6 +76,7 @@ func TestBuildDistributor(t *testing.T) {
 							Key: "c",
 						},
 					},
+					Affinity: manifestutils.DefaultAffinity(labels),
 					Containers: []corev1.Container{
 						{
 							Name:  "tempo",

--- a/internal/manifests/ingester/ingester.go
+++ b/internal/manifests/ingester/ingester.go
@@ -58,6 +58,7 @@ func statefulSet(params manifestutils.Params) (*v1.StatefulSet, error) {
 					ServiceAccountName: tempo.Spec.ServiceAccount,
 					NodeSelector:       cfg.NodeSelector,
 					Tolerations:        cfg.Tolerations,
+					Affinity:           manifestutils.DefaultAffinity(labels),
 					Containers: []corev1.Container{
 						{
 							Name:  "tempo",

--- a/internal/manifests/ingester/ingester_test.go
+++ b/internal/manifests/ingester/ingester_test.go
@@ -82,6 +82,7 @@ func TestBuildIngester(t *testing.T) {
 							Key: "c",
 						},
 					},
+					Affinity: manifestutils.DefaultAffinity(labels),
 					Containers: []corev1.Container{
 						{
 							Name:  "tempo",

--- a/internal/manifests/manifestutils/affinity.go
+++ b/internal/manifests/manifestutils/affinity.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// DefaultAffinity returns the default affinity for (most) of the Tempo components.
+// DefaultAffinity returns the default affinity for Tempo components.
 // It defines that two pods with the same labels (i.e. same component)
 // should not be scheduled on the same node or failure domain.
 func DefaultAffinity(labels labels.Set) *corev1.Affinity {

--- a/internal/manifests/manifestutils/affinity.go
+++ b/internal/manifests/manifestutils/affinity.go
@@ -1,0 +1,37 @@
+package manifestutils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// DefaultAffinity returns the default affinity for (most) of the Tempo components.
+// It defines that two pods with the same labels (i.e. same component)
+// should not be scheduled on the same node or failure domain.
+func DefaultAffinity(labels labels.Set) *corev1.Affinity {
+	return &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					Weight: 100,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: labels,
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+				{
+					Weight: 75,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: labels,
+						},
+						TopologyKey: "failure-domain.beta.kubernetes.io/zone",
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/manifests/querier/querier.go
+++ b/internal/manifests/querier/querier.go
@@ -59,6 +59,7 @@ func deployment(params manifestutils.Params) (*v1.Deployment, error) {
 					ServiceAccountName: tempo.Spec.ServiceAccount,
 					NodeSelector:       cfg.NodeSelector,
 					Tolerations:        cfg.Tolerations,
+					Affinity:           manifestutils.DefaultAffinity(labels),
 					Containers: []corev1.Container{
 						{
 							Name:  "tempo",

--- a/internal/manifests/querier/querier_test.go
+++ b/internal/manifests/querier/querier_test.go
@@ -110,6 +110,7 @@ func TestBuildQuerier(t *testing.T) {
 							Key: "c",
 						},
 					},
+					Affinity: manifestutils.DefaultAffinity(labels),
 					Containers: []corev1.Container{
 						{
 							Name:  "tempo",

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -72,29 +72,7 @@ func deployment(params manifestutils.Params) (*v1.Deployment, error) {
 					ServiceAccountName: tempo.Spec.ServiceAccount,
 					NodeSelector:       cfg.NodeSelector,
 					Tolerations:        cfg.Tolerations,
-					Affinity: &corev1.Affinity{
-						PodAntiAffinity: &corev1.PodAntiAffinity{
-							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-								{
-									Weight: 100,
-									PodAffinityTerm: corev1.PodAffinityTerm{
-										LabelSelector: &metav1.LabelSelector{
-											MatchLabels: labels,
-										},
-										TopologyKey: "failure-domain.beta.kubernetes.io/zone",
-									},
-								},
-							},
-							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: labels,
-									},
-									TopologyKey: "kubernetes.io/hostname",
-								},
-							},
-						},
-					},
+					Affinity:           manifestutils.DefaultAffinity(labels),
 					Containers: []corev1.Container{
 						{
 							Name:  "query-frontend",

--- a/internal/manifests/queryfrontend/query_frontend_test.go
+++ b/internal/manifests/queryfrontend/query_frontend_test.go
@@ -129,29 +129,7 @@ func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "tempo-test-serviceaccount",
-					Affinity: &corev1.Affinity{
-						PodAntiAffinity: &corev1.PodAntiAffinity{
-							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-								{
-									Weight: 100,
-									PodAffinityTerm: corev1.PodAffinityTerm{
-										LabelSelector: &metav1.LabelSelector{
-											MatchLabels: labels,
-										},
-										TopologyKey: "failure-domain.beta.kubernetes.io/zone",
-									},
-								},
-							},
-							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: labels,
-									},
-									TopologyKey: "kubernetes.io/hostname",
-								},
-							},
-						},
-					},
+					Affinity:           manifestutils.DefaultAffinity(labels),
 					Containers: []corev1.Container{
 						{
 							Name:  "query-frontend",


### PR DESCRIPTION
Using slightly modified best practices from the tempo-distributed helm chart at https://github.com/grafana/helm-charts/blob/main/charts/tempo-distributed/values.yaml.

In the helm chart
* distributor, query and query-frontend use podAntiAffinity with requiredDuringSchedulingIgnoredDuringExecution so that a pod cannot be scheduled on the same node twice, and preferredDuringSchedulingIgnoredDuringExecution for the failure domain
* ingester uses podAntiAffinity with preferredDuringSchedulingIgnoredDuringExecution so that a pod should not be scheduled on the same node or failure domain twice
* compactor has no podAntiAffinity set

In this PR distributor, query, query-frontend and ingester components get a podAntiAffinity with preferredDuringSchedulingIgnoredDuringExecution so that a pod should not be scheduled on the same node or failure domain twice. It's a "soft" affinity, i.e. if it cannot be satisfied (for example if the cluster only has a single node), the pod will still get scheduled (see #140).

Resolves: #140