### PR TITLE
Set SecurityContext and mount /var/tempo in emptyDir volumes

### DIFF
--- a/internal/manifests/compactor/compactor.go
+++ b/internal/manifests/compactor/compactor.go
@@ -82,8 +82,13 @@ func deployment(params manifestutils.Params) (*v1.Deployment, error) {
 									MountPath: "/conf",
 									ReadOnly:  true,
 								},
+								{
+									Name:      manifestutils.TmpStorageVolumeName,
+									MountPath: manifestutils.TmpStoragePath,
+								},
 							},
-							Resources: manifestutils.Resources(tempo, componentName),
+							Resources:       manifestutils.Resources(tempo, componentName),
+							SecurityContext: manifestutils.TempoContainerSecurityContext(),
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -95,6 +100,12 @@ func deployment(params manifestutils.Params) (*v1.Deployment, error) {
 										Name: naming.Name("", tempo.Name),
 									},
 								},
+							},
+						},
+						{
+							Name: manifestutils.TmpStorageVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},

--- a/internal/manifests/compactor/compactor_test.go
+++ b/internal/manifests/compactor/compactor_test.go
@@ -115,6 +115,10 @@ func TestBuildCompactor(t *testing.T) {
 									MountPath: "/conf",
 									ReadOnly:  true,
 								},
+								{
+									Name:      manifestutils.TmpStorageVolumeName,
+									MountPath: manifestutils.TmpStoragePath,
+								},
 							},
 							Ports: []corev1.ContainerPort{
 								{
@@ -138,6 +142,7 @@ func TestBuildCompactor(t *testing.T) {
 									corev1.ResourceMemory: *resource.NewQuantity(115964128, resource.BinarySI),
 								},
 							},
+							SecurityContext: manifestutils.TempoContainerSecurityContext(),
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -149,6 +154,12 @@ func TestBuildCompactor(t *testing.T) {
 										Name: "tempo-test",
 									},
 								},
+							},
+						},
+						{
+							Name: manifestutils.TmpStorageVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},

--- a/internal/manifests/distributor/distributor.go
+++ b/internal/manifests/distributor/distributor.go
@@ -82,8 +82,13 @@ func deployment(params manifestutils.Params) *v1.Deployment {
 									MountPath: "/conf",
 									ReadOnly:  true,
 								},
+								{
+									Name:      manifestutils.TmpStorageVolumeName,
+									MountPath: manifestutils.TmpStoragePath,
+								},
 							},
-							Resources: manifestutils.Resources(tempo, componentName),
+							Resources:       manifestutils.Resources(tempo, componentName),
+							SecurityContext: manifestutils.TempoContainerSecurityContext(),
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -95,6 +100,12 @@ func deployment(params manifestutils.Params) *v1.Deployment {
 										Name: naming.Name("", tempo.Name),
 									},
 								},
+							},
+						},
+						{
+							Name: manifestutils.TmpStorageVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},

--- a/internal/manifests/distributor/distributor_test.go
+++ b/internal/manifests/distributor/distributor_test.go
@@ -87,6 +87,10 @@ func TestBuildDistributor(t *testing.T) {
 									MountPath: "/conf",
 									ReadOnly:  true,
 								},
+								{
+									Name:      manifestutils.TmpStorageVolumeName,
+									MountPath: manifestutils.TmpStoragePath,
+								},
 							},
 							Ports: []corev1.ContainerPort{
 								{
@@ -115,6 +119,7 @@ func TestBuildDistributor(t *testing.T) {
 									corev1.ResourceMemory: *resource.NewQuantity(77309416, resource.BinarySI),
 								},
 							},
+							SecurityContext: manifestutils.TempoContainerSecurityContext(),
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -126,6 +131,12 @@ func TestBuildDistributor(t *testing.T) {
 										Name: "tempo-test",
 									},
 								},
+							},
+						},
+						{
+							Name: manifestutils.TmpStorageVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},

--- a/internal/manifests/ingester/ingester.go
+++ b/internal/manifests/ingester/ingester.go
@@ -91,7 +91,8 @@ func statefulSet(params manifestutils.Params) (*v1.StatefulSet, error) {
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},
-							Resources: manifestutils.Resources(tempo, componentName),
+							Resources:       manifestutils.Resources(tempo, componentName),
+							SecurityContext: manifestutils.TempoContainerSecurityContext(),
 						},
 					},
 					Volumes: []corev1.Volume{

--- a/internal/manifests/ingester/ingester_test.go
+++ b/internal/manifests/ingester/ingester_test.go
@@ -151,6 +151,7 @@ func TestBuildIngester(t *testing.T) {
 									corev1.ResourceMemory: *resource.NewQuantity(322122560, resource.BinarySI),
 								},
 							},
+							SecurityContext: manifestutils.TempoContainerSecurityContext(),
 						},
 					},
 					Volumes: []corev1.Volume{

--- a/internal/manifests/manifestutils/constants.go
+++ b/internal/manifests/manifestutils/constants.go
@@ -10,6 +10,12 @@ const (
 	// ConfigVolumeName declares the name of the volume containing the tempo configuration.
 	ConfigVolumeName = "tempo-conf"
 
+	// TmpStorageVolumeName declares the name of the volume containing temporary storage for tempo.
+	TmpStorageVolumeName = "tempo-tmp-storage"
+
+	// TmpStoragePath declares the path of temporary storage for tempo.
+	TmpStoragePath = "/var/tempo"
+
 	// HttpPortName declares the name of the tempo http port.
 	HttpPortName = "http"
 	// PortHTTPServer declares the port number of the tempo http port.

--- a/internal/manifests/manifestutils/securitycontext.go
+++ b/internal/manifests/manifestutils/securitycontext.go
@@ -1,0 +1,16 @@
+package manifestutils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TempoContainerSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: pointer.Bool(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		ReadOnlyRootFilesystem: pointer.Bool(true),
+	}
+}

--- a/internal/manifests/querier/querier.go
+++ b/internal/manifests/querier/querier.go
@@ -82,8 +82,13 @@ func deployment(params manifestutils.Params) (*v1.Deployment, error) {
 									MountPath: "/conf",
 									ReadOnly:  true,
 								},
+								{
+									Name:      manifestutils.TmpStorageVolumeName,
+									MountPath: manifestutils.TmpStoragePath,
+								},
 							},
-							Resources: manifestutils.Resources(tempo, componentName),
+							Resources:       manifestutils.Resources(tempo, componentName),
+							SecurityContext: manifestutils.TempoContainerSecurityContext(),
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -95,6 +100,12 @@ func deployment(params manifestutils.Params) (*v1.Deployment, error) {
 										Name: naming.Name("", tempo.Name),
 									},
 								},
+							},
+						},
+						{
+							Name: manifestutils.TmpStorageVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},

--- a/internal/manifests/querier/querier_test.go
+++ b/internal/manifests/querier/querier_test.go
@@ -121,6 +121,10 @@ func TestBuildQuerier(t *testing.T) {
 									MountPath: "/conf",
 									ReadOnly:  true,
 								},
+								{
+									Name:      manifestutils.TmpStorageVolumeName,
+									MountPath: manifestutils.TmpStoragePath,
+								},
 							},
 							Ports: []corev1.ContainerPort{
 								{
@@ -144,6 +148,7 @@ func TestBuildQuerier(t *testing.T) {
 									corev1.ResourceMemory: *resource.NewQuantity(96636768, resource.BinarySI),
 								},
 							},
+							SecurityContext: manifestutils.TempoContainerSecurityContext(),
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -155,6 +160,12 @@ func TestBuildQuerier(t *testing.T) {
 										Name: "tempo-test",
 									},
 								},
+							},
+						},
+						{
+							Name: manifestutils.TmpStorageVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},

--- a/internal/manifests/queryfrontend/query_frontend.go
+++ b/internal/manifests/queryfrontend/query_frontend.go
@@ -123,11 +123,12 @@ func deployment(params manifestutils.Params) (*v1.Deployment, error) {
 									ReadOnly:  true,
 								},
 								{
-									Name:      "data-querier-frontend",
-									MountPath: "/var/tempo",
+									Name:      manifestutils.TmpStorageVolumeName,
+									MountPath: manifestutils.TmpStoragePath,
 								},
 							},
-							Resources: manifestutils.Resources(tempo, componentName),
+							Resources:       manifestutils.Resources(tempo, componentName),
+							SecurityContext: manifestutils.TempoContainerSecurityContext(),
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -142,7 +143,7 @@ func deployment(params manifestutils.Params) (*v1.Deployment, error) {
 							},
 						},
 						{
-							Name: "data-querier-frontend",
+							Name: manifestutils.TmpStorageVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
@@ -181,14 +182,14 @@ func deployment(params manifestutils.Params) (*v1.Deployment, error) {
 					ReadOnly:  true,
 				},
 				{
-					Name:      "data-query",
-					MountPath: "/var/tempo",
+					Name:      manifestutils.TmpStorageVolumeName + "-query",
+					MountPath: manifestutils.TmpStoragePath,
 				},
 			},
 			Resources: manifestutils.Resources(tempo, componentName),
 		}
 		jaegerQueryVolume := corev1.Volume{
-			Name: "data-query",
+			Name: manifestutils.TmpStorageVolumeName + "-query",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},

--- a/internal/manifests/queryfrontend/query_frontend_test.go
+++ b/internal/manifests/queryfrontend/query_frontend_test.go
@@ -180,8 +180,8 @@ func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 									ReadOnly:  true,
 								},
 								{
-									Name:      "data-querier-frontend",
-									MountPath: "/var/tempo",
+									Name:      manifestutils.TmpStorageVolumeName,
+									MountPath: manifestutils.TmpStoragePath,
 								},
 							},
 							Resources: corev1.ResourceRequirements{
@@ -194,6 +194,7 @@ func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 									corev1.ResourceMemory: *resource.NewQuantity(32212256, resource.BinarySI),
 								},
 							},
+							SecurityContext: manifestutils.TempoContainerSecurityContext(),
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -208,7 +209,7 @@ func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 							},
 						},
 						{
-							Name: "data-querier-frontend",
+							Name: manifestutils.TmpStorageVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
@@ -247,8 +248,8 @@ func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 					ReadOnly:  true,
 				},
 				{
-					Name:      "data-query",
-					MountPath: "/var/tempo",
+					Name:      manifestutils.TmpStorageVolumeName + "-query",
+					MountPath: manifestutils.TmpStoragePath,
 				},
 			},
 			Resources: corev1.ResourceRequirements{
@@ -263,7 +264,7 @@ func getExpectedDeployment(withJaeger bool) *v1.Deployment {
 			},
 		}
 		jaegerQueryVolume := corev1.Volume{
-			Name: "data-query",
+			Name: manifestutils.TmpStorageVolumeName + "-query",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},


### PR DESCRIPTION
This resolves permission errors on OpenShift (the user in the container has no permissions to write to /var/tempo inside the container FS) and improves security by preventing writes to the container FS, disallowing privilege escalation and dropping all capabilities.

Ref. https://github.com/grafana/helm-charts/pull/1672
tempo-query filesystem cannot be set to readonly due to https://github.com/grafana/tempo/issues/1621