### PR TITLE
Validate storage secret in webhook if it exists

### DIFF
--- a/apis/tempo/v1alpha1/microservices_webhook.go
+++ b/apis/tempo/v1alpha1/microservices_webhook.go
@@ -187,7 +187,7 @@ func ValidateStorageSecret(tempo Microservices, storageSecret corev1.Secret) fie
 				allErrs = append(allErrs, field.Invalid(
 					path,
 					tempo.Spec.Storage.Secret,
-					"'endpoint' field of storage secret must be a valid URL",
+					"\"endpoint\" field of storage secret must be a valid URL",
 				))
 			}
 		}

--- a/apis/tempo/v1alpha1/microservices_webhook_test.go
+++ b/apis/tempo/v1alpha1/microservices_webhook_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -157,6 +158,92 @@ func TestDefault(t *testing.T) {
 	}
 }
 
+func TestValidateStorageSecret(t *testing.T) {
+	tempo := Microservices{
+		Spec: MicroservicesSpec{
+			Storage: ObjectStorageSpec{
+				Secret: "testsecret",
+			},
+		},
+	}
+	path := field.NewPath("spec").Child("storage").Child("secret")
+
+	tests := []struct {
+		name     string
+		input    corev1.Secret
+		expected field.ErrorList
+	}{
+		{
+			name:  "empty secret",
+			input: corev1.Secret{},
+			expected: field.ErrorList{
+				field.Invalid(path, tempo.Spec.Storage.Secret, "storage secret is empty"),
+			},
+		},
+		{
+			name: "missing or empty fields",
+			input: corev1.Secret{
+				Data: map[string][]byte{
+					"bucket": []byte(""),
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(path, tempo.Spec.Storage.Secret, "storage secret must contain \"endpoint\" field"),
+				field.Invalid(path, tempo.Spec.Storage.Secret, "storage secret must contain \"bucket\" field"),
+				field.Invalid(path, tempo.Spec.Storage.Secret, "storage secret must contain \"access_key_id\" field"),
+				field.Invalid(path, tempo.Spec.Storage.Secret, "storage secret must contain \"access_key_secret\" field"),
+			},
+		},
+		{
+			name: "invalid endpoint 'invalid'",
+			input: corev1.Secret{
+				Data: map[string][]byte{
+					"endpoint":          []byte("invalid"),
+					"bucket":            []byte("bucket"),
+					"access_key_id":     []byte("id"),
+					"access_key_secret": []byte("secret"),
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(path, tempo.Spec.Storage.Secret, "'endpoint' field of storage secret must be a valid URL"),
+			},
+		},
+		{
+			name: "invalid endpoint '/invalid'",
+			input: corev1.Secret{
+				Data: map[string][]byte{
+					"endpoint":          []byte("/invalid"),
+					"bucket":            []byte("bucket"),
+					"access_key_id":     []byte("id"),
+					"access_key_secret": []byte("secret"),
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(path, tempo.Spec.Storage.Secret, "'endpoint' field of storage secret must be a valid URL"),
+			},
+		},
+		{
+			name: "valid storage secret",
+			input: corev1.Secret{
+				Data: map[string][]byte{
+					"endpoint":          []byte("http://minio.minio.svc:9000"),
+					"bucket":            []byte("bucket"),
+					"access_key_id":     []byte("id"),
+					"access_key_secret": []byte("secret"),
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			errs := ValidateStorageSecret(tempo, test.input)
+			assert.Equal(t, test.expected, errs)
+		})
+	}
+}
+
 func TestValidateReplicationFactor(t *testing.T) {
 	validator := &validator{}
 	path := field.NewPath("spec").Child("ReplicationFactor")
@@ -215,7 +302,7 @@ func TestValidateReplicationFactor(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			errs := validator.validateReplicationFactor(&test.input)
+			errs := validator.validateReplicationFactor(test.input)
 			assert.Equal(t, test.expected, errs)
 		})
 	}

--- a/apis/tempo/v1alpha1/microservices_webhook_test.go
+++ b/apis/tempo/v1alpha1/microservices_webhook_test.go
@@ -205,7 +205,7 @@ func TestValidateStorageSecret(t *testing.T) {
 				},
 			},
 			expected: field.ErrorList{
-				field.Invalid(path, tempo.Spec.Storage.Secret, "'endpoint' field of storage secret must be a valid URL"),
+				field.Invalid(path, tempo.Spec.Storage.Secret, "\"endpoint\" field of storage secret must be a valid URL"),
 			},
 		},
 		{
@@ -219,7 +219,7 @@ func TestValidateStorageSecret(t *testing.T) {
 				},
 			},
 			expected: field.ErrorList{
-				field.Invalid(path, tempo.Spec.Storage.Secret, "'endpoint' field of storage secret must be a valid URL"),
+				field.Invalid(path, tempo.Spec.Storage.Secret, "\"endpoint\" field of storage secret must be a valid URL"),
 			},
 		},
 		{

--- a/controllers/tempo/microservices_controller.go
+++ b/controllers/tempo/microservices_controller.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -159,24 +159,6 @@ func (r *MicroservicesReconciler) reconcileManifests(ctx context.Context, log lo
 	return nil
 }
 
-func validateStorageSecret(storageSecret *corev1.Secret) error {
-	if storageSecret.Data == nil ||
-		storageSecret.Data["endpoint"] == nil ||
-		storageSecret.Data["bucket"] == nil ||
-		storageSecret.Data["access_key_id"] == nil ||
-		storageSecret.Data["access_key_secret"] == nil {
-		return fmt.Errorf("storage secret should contain endpoint and bucket, access_key_id and access_key_secret fields")
-	}
-
-	u, err := url.ParseRequestURI(string(storageSecret.Data["endpoint"]))
-	// ParseRequestURI also accepts absolute paths, therefore we need to check if the URL scheme is set
-	if err != nil || u.Scheme == "" {
-		return fmt.Errorf("'endpoint' field of storage secret must be a valid URL")
-	}
-
-	return nil
-}
-
 func (r *MicroservicesReconciler) getStorageConfig(ctx context.Context, tempo v1alpha1.Microservices) (*manifestutils.StorageParams, error) {
 	storageSecret := &corev1.Secret{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: tempo.Namespace, Name: tempo.Spec.Storage.Secret}, storageSecret)
@@ -184,9 +166,13 @@ func (r *MicroservicesReconciler) getStorageConfig(ctx context.Context, tempo v1
 		return nil, fmt.Errorf("could not fetch storage secret: %w", err)
 	}
 
-	err = validateStorageSecret(storageSecret)
-	if err != nil {
-		return nil, fmt.Errorf("invalid storage secret: %w", err)
+	fieldErrs := v1alpha1.ValidateStorageSecret(tempo, *storageSecret)
+	if len(fieldErrs) > 0 {
+		msgs := make([]string, len(fieldErrs))
+		for i, fieldErr := range fieldErrs {
+			msgs[i] = fieldErr.Detail
+		}
+		return nil, fmt.Errorf("invalid storage secret: %s", strings.Join(msgs, ", "))
 	}
 
 	return &manifestutils.StorageParams{S3: manifestutils.S3{


### PR DESCRIPTION
This partially reverts https://github.com/os-observability/tempo-operator/pull/167 and brings back validation of the storage secret in the validation webhook.

However, a missing secret does not fail the validation. Instead, the cluster will be in a degraded state until the storage secret is set.
This is helpful in case manifests get applied out of order, i.e. the Tempo CR gets created before the storage secret.

I also fixed an error where the condition message didn't get updated when an invalid secret got updated (e.g. a secret with a missing endpoint got updated to add an invalid endpoint).

cc @pavolloffay 