### PR TITLE
Update default tempo HTTP port to 3200

### DIFF
--- a/internal/manifests/config/build.go
+++ b/internal/manifests/config/build.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
+	"github.com/os-observability/tempo-operator/internal/manifests/manifestutils"
 	"github.com/os-observability/tempo-operator/internal/manifests/naming"
 )
 
@@ -61,7 +62,7 @@ func buildConfiguration(tempo v1alpha1.Microservices, params Params) ([]byte, er
 		MemberList: []string{
 			naming.Name("gossip-ring", tempo.Name),
 		},
-		QueryFrontendDiscovery: fmt.Sprintf("%s:9095", naming.Name("query-frontend-discovery", tempo.Name)),
+		QueryFrontendDiscovery: fmt.Sprintf("%s:%d", naming.Name("query-frontend-discovery", tempo.Name), manifestutils.PortGRPCServer),
 		GlobalRateLimits:       fromRateLimitSpecToRateLimitOptions(tempo.Spec.LimitSpec.Global),
 		Search:                 fromSearchSpecToOptions(tempo.Spec.SearchSpec),
 		ReplicationFactor:      tempo.Spec.ReplicationFactor,

--- a/internal/manifests/config/build_test.go
+++ b/internal/manifests/config/build_test.go
@@ -59,7 +59,7 @@ search_enabled: false
 server: 
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt
@@ -154,7 +154,7 @@ search_enabled: false
 server: 
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt
@@ -231,7 +231,7 @@ search_enabled: false
 server: 
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt
@@ -307,7 +307,7 @@ search_enabled: false
 server: 
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt
@@ -384,7 +384,7 @@ search_enabled: false
 server: 
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt
@@ -461,7 +461,7 @@ search_enabled: false
 server: 
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt
@@ -538,7 +538,7 @@ search_enabled: false
 server: 
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt
@@ -615,7 +615,7 @@ search_enabled: false
 server: 
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt
@@ -704,7 +704,7 @@ search_enabled: false
 server: 
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt
@@ -791,7 +791,7 @@ search_enabled: false
 server: 
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt
@@ -930,7 +930,7 @@ search_enabled: true
 server: 
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt
@@ -1026,7 +1026,7 @@ search_enabled: false
 server: 
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt

--- a/internal/manifests/config/configmap.go
+++ b/internal/manifests/config/configmap.go
@@ -51,7 +51,7 @@ func BuildConfigMap(tempo v1alpha1.Microservices, params Params) (*corev1.Config
 		},
 	}
 	if tempo.Spec.Components.QueryFrontend.JaegerQuery.Enabled {
-		configMap.Data["tempo-query.yaml"] = "backend: 127.0.0.1:3100\n"
+		configMap.Data["tempo-query.yaml"] = fmt.Sprintf("backend: 127.0.0.1:%d\n", manifestutils.PortHTTPServer)
 	}
 
 	// We only need to hash the main ConfigMap, the per-tenant overrides

--- a/internal/manifests/config/tempo-config.yaml
+++ b/internal/manifests/config/tempo-config.yaml
@@ -89,7 +89,7 @@ search_enabled: {{ .Search.Enabled }}
 server:
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 3m
   http_server_write_timeout: 3m
   log_format: logfmt

--- a/internal/manifests/manifestutils/constants.go
+++ b/internal/manifests/manifestutils/constants.go
@@ -19,7 +19,7 @@ const (
 	// HttpPortName declares the name of the tempo http port.
 	HttpPortName = "http"
 	// PortHTTPServer declares the port number of the tempo http port.
-	PortHTTPServer = 3100
+	PortHTTPServer = 3200
 	// TempoReadinessPath specifies the path for the readiness probe.
 	TempoReadinessPath = "/ready"
 	// TempoLivenessPath specifies the path for the liveness probe.

--- a/tests/e2e/generate/01-assert.yaml
+++ b/tests/e2e/generate/01-assert.yaml
@@ -37,7 +37,7 @@ spec:
       protocol: TCP
       targetPort: otlp-grpc
     - name: http
-      port: 3100
+      port: 3200
       protocol: TCP
       targetPort: http
   selector:

--- a/tests/e2e/reconcile/01-assert.yaml
+++ b/tests/e2e/reconcile/01-assert.yaml
@@ -15,7 +15,7 @@ spec:
       protocol: TCP
       targetPort: http-memberlist
     - name: http
-      port: 3100
+      port: 3200
       protocol: TCP
       targetPort: http
     - name: grpc

--- a/tests/e2e/reconcile/02-assert.yaml
+++ b/tests/e2e/reconcile/02-assert.yaml
@@ -15,7 +15,7 @@ spec:
       protocol: TCP
       targetPort: http-memberlist
     - name: http
-      port: 3100
+      port: 3200
       protocol: TCP
       targetPort: http
     - name: grpc

--- a/tests/e2e/smoketest-with-jaeger/01-assert.yaml
+++ b/tests/e2e/smoketest-with-jaeger/01-assert.yaml
@@ -149,7 +149,7 @@ spec:
       protocol: TCP
       targetPort: http-memberlist
     - name: http
-      port: 3100
+      port: 3200
       protocol: TCP
       targetPort: http
   selector:
@@ -176,7 +176,7 @@ spec:
       protocol: TCP
       targetPort: otlp-grpc
     - name: http
-      port: 3100
+      port: 3200
       protocol: TCP
       targetPort: http
   selector:
@@ -222,7 +222,7 @@ metadata:
 spec:
   ports:
     - name: http
-      port: 3100
+      port: 3200
       protocol: TCP
       targetPort: http
     - name: grpc
@@ -253,7 +253,7 @@ spec:
       protocol: TCP
       targetPort: http-memberlist
     - name: http
-      port: 3100
+      port: 3200
       protocol: TCP
       targetPort: http
     - name: grpc
@@ -280,7 +280,7 @@ metadata:
 spec:
   ports:
     - name: http
-      port: 3100
+      port: 3200
       protocol: TCP
       targetPort: http
     - name: grpc
@@ -316,7 +316,7 @@ spec:
   clusterIP: None
   ports:
     - name: http
-      port: 3100
+      port: 3200
       protocol: TCP
       targetPort: http
     - name: grpc


### PR DESCRIPTION
Upstream tempo updated the default port to 3200, let's also update the default port in the operator.

Resolves: #128
Signed-off-by: Andreas Gerstmayr <agerstmayr@redhat.com>