### PR TITLE
Set OCP oauth redirect URL dynamically

### DIFF
--- a/apis/config/v1alpha1/projectconfig_types.go
+++ b/apis/config/v1alpha1/projectconfig_types.go
@@ -40,6 +40,9 @@ type OpenShiftFeatureGates struct {
 	// gateway to expose the service to public internet access.
 	// More details: https://docs.openshift.com/container-platform/latest/networking/understanding-networking.html
 	GatewayRoute bool `json:"gatewayRoute,omitempty"`
+
+	// BaseDomain is used internally for redirect URL in gateway OpenShift auth mode.
+	BaseDomain string `json:"baseDomain,omitempty"`
 }
 
 // FeatureGates is the supported set of all operator feature gates.

--- a/apis/config/v1alpha1/projectconfig_types.go
+++ b/apis/config/v1alpha1/projectconfig_types.go
@@ -42,6 +42,7 @@ type OpenShiftFeatureGates struct {
 	GatewayRoute bool `json:"gatewayRoute,omitempty"`
 
 	// BaseDomain is used internally for redirect URL in gateway OpenShift auth mode.
+	// If empty the operator automatically derives the domain from the cluster.
 	BaseDomain string `json:"baseDomain,omitempty"`
 }
 

--- a/apis/tempo/v1alpha1/microservices_types.go
+++ b/apis/tempo/v1alpha1/microservices_types.go
@@ -214,6 +214,8 @@ const (
 	ReasonFailedComponents ConditionReason = "FailedComponents"
 	// ReasonPendingComponents when all/some Tempo components pending dependencies.
 	ReasonPendingComponents ConditionReason = "PendingComponents"
+	// ReasonCouldNotGetOpenShiftBaseDomain when operator cannot get OpenShift base domain, that is used for OAuth redirect URL.
+	ReasonCouldNotGetOpenShiftBaseDomain ConditionReason = "CouldNotGetOpenShiftBaseDomain"
 )
 
 // PermissionType is a Tempo Gateway RBAC permission.

--- a/bundle/manifests/tempo-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tempo-operator.clusterserviceversion.yaml
@@ -420,6 +420,22 @@ spec:
           - update
           - watch
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - dnses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - ingresscontrollers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"fmt"
 
+	configv1 "github.com/openshift/api/config/v1"
+	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,7 +37,9 @@ func init() {
 
 	utilruntime.Must(tempov1alpha1.AddToScheme(scheme))
 	utilruntime.Must(configtempov1alpha1.AddToScheme(scheme))
-	utilruntime.Must(routev1.AddToScheme(scheme))
+	utilruntime.Must(routev1.Install(scheme))
+	utilruntime.Must(openshiftoperatorv1.Install(scheme))
+	utilruntime.Must(configv1.Install(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,6 +35,22 @@ rules:
   - update
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - dnses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - ingresscontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.27 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.20 // indirect
-	github.com/openshift/api v3.9.0+incompatible
+	github.com/openshift/api v0.0.0-20230213202419-42edf4f1d905
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.62.0
 	github.com/stretchr/testify v1.8.1
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -316,6 +316,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.27.1 h1:rfztXRbg6nv/5f+Raen9RcGoSecHIFgBBLQK3Wdj754=
 github.com/onsi/gomega v1.27.1/go.mod h1:aHX5xOykVYzWOV4WqQy0sy8BQptgukenXpCXfadcIAw=
+github.com/openshift/api v0.0.0-20230213202419-42edf4f1d905 h1:f+W57UXpRIJeZIh9lGLIPix/YxdFDBgHDGo0OkIgQw0=
+github.com/openshift/api v0.0.0-20230213202419-42edf4f1d905/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
 github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/library-go v0.0.0-20220622115547-84d884f4c9f6 h1:lmfmsIGq62lmj17qrZh4Gbbb86WvJw6pLhCNwNjB2Yk=

--- a/internal/handlers/gateway/basedomain.go
+++ b/internal/handlers/gateway/basedomain.go
@@ -1,0 +1,43 @@
+package gateway
+
+import (
+	"context"
+
+	"github.com/ViaQ/logerr/v2/kverrors"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/os-observability/tempo-operator/apis/tempo/v1alpha1"
+	"github.com/os-observability/tempo-operator/internal/status"
+)
+
+// GetOpenShiftBaseDomain returns base domain of OCP cluster.
+func GetOpenShiftBaseDomain(ctx context.Context, client k8sclient.Client) (string, error) {
+	ictrl := &operatorv1.IngressController{}
+	nsn := types.NamespacedName{Name: "default", Namespace: "openshift-ingress-operator"}
+	err := client.Get(ctx, nsn, ictrl)
+	if err != nil {
+		// The preferred way to get the base domain is via OCP ingress controller
+		// this approach works well with CRC and normal OCP cluster.
+		// Fallback on cluster DNS might not work with CRC because CRC uses .apps-crc. and not .apps.
+		key := k8sclient.ObjectKey{Name: "cluster"}
+		var clusterDNS configv1.DNS
+		if err := client.Get(ctx, key, &clusterDNS); err != nil {
+			if apierrors.IsNotFound(err) {
+				return "", &status.DegradedError{
+					Message: "Missing OpenShift ingresscontroller and cluster DNS configuration to read base domain",
+					Reason:  v1alpha1.ReasonCouldNotGetOpenShiftBaseDomain,
+					Requeue: true,
+				}
+			}
+			return "", kverrors.Wrap(err, "failed to lookup gateway base domain",
+				"name", key)
+		}
+
+		return "", err
+	}
+	return ictrl.Status.Domain, nil
+}

--- a/internal/manifests/gateway/configs.go
+++ b/internal/manifests/gateway/configs.go
@@ -44,6 +44,7 @@ func buildConfigFiles(opts options) (rbacCfg string, tenantsCfg string, err erro
 type options struct {
 	Namespace     string
 	Name          string
+	BaseDomain    string
 	Tenants       *v1alpha1.TenantsSpec
 	TenantSecrets []*tenantSecret
 }

--- a/internal/manifests/gateway/configs_test.go
+++ b/internal/manifests/gateway/configs_test.go
@@ -112,6 +112,7 @@ func TestTenantsTemplate(t *testing.T) {
 			opts: options{
 				Namespace:     "default",
 				Name:          "foo",
+				BaseDomain:    "apps-crc.testing",
 				TenantSecrets: nil,
 				Tenants: &v1alpha1.TenantsSpec{
 					Mode: v1alpha1.OpenShift,

--- a/internal/manifests/gateway/gateway-tenants.yaml
+++ b/internal/manifests/gateway/gateway-tenants.yaml
@@ -7,7 +7,7 @@ tenants:
 {{- if eq $opt.Tenants.Mode "openshift" }}
   openshift:
     serviceAccount: tempo-{{ $opt.Name }}-gateway
-    redirectURL: https://tempo-{{ $opt.Name}}-gateway-{{ $opt.Namespace }}.apps-crc.testing/openshift/dev/callback
+    redirectURL: https://tempo-{{ $opt.Name}}-gateway-{{ $opt.Namespace }}.{{ $opt.BaseDomain }}/openshift/dev/callback
 {{- end -}}
 {{- if $spec.OIDC -}}
   oidc:

--- a/internal/manifests/gateway/gateway.go
+++ b/internal/manifests/gateway/gateway.go
@@ -39,9 +39,10 @@ func BuildGateway(params manifestutils.Params) ([]client.Object, error) {
 		return []client.Object{}, nil
 	}
 	rbacCfg, tenantsCfg, err := buildConfigFiles(options{
-		Namespace: params.Tempo.Namespace,
-		Name:      params.Tempo.Name,
-		Tenants:   params.Tempo.Spec.Tenants,
+		Namespace:  params.Tempo.Namespace,
+		Name:       params.Tempo.Name,
+		BaseDomain: params.Gates.OpenShift.BaseDomain,
+		Tenants:    params.Tempo.Spec.Tenants,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Resolves #244 

Tested on CRC with 

```yaml
kubectl apply -f - <<EOF
apiVersion: tempo.grafana.com/v1alpha1
kind: Microservices
metadata:
  name: simplest
spec:
  storage:
    secret: minio-test
  storageSize: 1Gi
  resources:
    total:
      limits:
        memory: 2Gi
        cpu: 2000m
  tenants:
    mode: openshift
    authentication:
      - tenantName: dev
        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfa"
      - tenantName: production
        tenantId: "1610b0c3-c509-4592-a256-a1871353dbfb"
    authorization:
      roleBindings:
      - name: read-write
        roles:
          - read-write-traces
        subjects:
          - kind: user
            name: system:serviceaccount:ploffay:dev-collector
          - kind: user
            name: system:serviceaccount:ploffay:production-collector
          - kind: user
            name: kubeadmin
      roles:
      - name: read-write-traces
        permissions:
          - read
          - write
        resources: 
          - traces
        tenants:
          - dev
          - production
  template:
    gateway:
      enabled: true
    queryFrontend:
      jaegerQuery:
        enabled: true
EOF
```
