### PR TITLE
Cache tool dependencies in docker layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM golang:1.19 as builder
 
 WORKDIR /workspace
+# Cache tool dependencies
+COPY Makefile Makefile
+RUN make controller-gen crdoc kustomize
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum


### PR DESCRIPTION
make build runs the generate task, which depends on controller-gen, crdoc and kustomize.