### PR TITLE
fix: gateway crashloop on k8s

### DIFF
--- a/internal/manifests/gateway/configs_test.go
+++ b/internal/manifests/gateway/configs_test.go
@@ -108,6 +108,32 @@ func TestTenantsTemplate(t *testing.T) {
   id: abcd1`,
 		},
 		{
+			name: "with oidc",
+			opts: options{
+				Namespace:     "default",
+				Name:          "foo",
+				TenantSecrets: nil,
+				Tenants: &v1alpha1.TenantsSpec{
+					Mode: v1alpha1.Static,
+					Authentication: []v1alpha1.AuthenticationSpec{
+						{
+							TenantName: "dev",
+							TenantID:   "abcd1",
+							OIDC: &v1alpha1.OIDCSpec{
+								IssuerURL: "https://something.com",
+							},
+						},
+					},
+				},
+			},
+			expected: `tenants:
+- name: dev
+  id: abcd1
+  oidc:
+    issuerURL: https://something.com
+    `,
+		},
+		{
 			name: "openshift",
 			opts: options{
 				Namespace:     "default",

--- a/internal/manifests/gateway/gateway-tenants.yaml
+++ b/internal/manifests/gateway/gateway-tenants.yaml
@@ -9,7 +9,7 @@ tenants:
     serviceAccount: tempo-{{ $opt.Name }}-gateway
     redirectURL: https://tempo-{{ $opt.Name}}-gateway-{{ $opt.Namespace }}.{{ $opt.BaseDomain }}/openshift/dev/callback
 {{- end -}}
-{{- if $spec.OIDC -}}
+{{- if $spec.OIDC }}
   oidc:
     {{- range $secret := $opt.TenantSecrets }}
     {{- if eq $secret.TenantName $spec.TenantName -}}


### PR DESCRIPTION
**Testing**
```
apiVersion: tempo.grafana.com/v1alpha1
kind: Microservices
metadata:
  name: foo
spec:
  images:
    tempo: docker.io/grafana/tempo:1.5.0
    tempoQuery: docker.io/grafana/tempo-query:main-0c1eb27
    tempoGateway: ghcr.io/frzifus/obs-api:print-tenant
  template:
    queryFrontend:
      jaegerQuery:
        enabled: true
    gateway:
      enabled: true
  storage:
    secret: minio-test
  storageSize: 200M
  tenants:
    mode: static
    authentication:
      - tenantName: test-oidc
        tenantId: test-oidc
        oidc:
          secret:
            name: test-oidc
          issuerURL: https://dex.klimlive.de/dex
    authorization:
      roleBindings:
      - name: test-oidc
        roles:
        - read-write
        subjects:
        - kind: user
          name: user
      roles:
      - name: read-write
        permissions:
        - read
        - write
        resources:
        - logs
        - metrics
        - traces
        tenants:
        - test-oidc
```

---

```bash
go run main.go generate --cr install.yaml > out.yaml
```
