### PR TITLE
Fix e2e smoketest on OpenShift

### DIFF
--- a/tests/e2e/smoketest-with-jaeger/03-run-check-services.yaml
+++ b/tests/e2e/smoketest-with-jaeger/03-run-check-services.yaml
@@ -2,6 +2,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   # This is a hacky but simple way of determining if any of the traces created by tracegen were received.  It should be considered temporary.
-  - command: 'kubectl exec --namespace $NAMESPACE deployment/tempo-simplest-query-frontend --container tempo-query -- sh  -c "rm -f services ; wget -q http://localhost:16686/api/services ; cat services | grep -i tracegen"'
+  - command: 'kubectl exec --namespace $NAMESPACE deployment/tempo-simplest-query-frontend --container tempo-query -- sh -c "wget -q -O- http://localhost:16686/api/services | grep -i tracegen"'
     namespaced: true
-


### PR DESCRIPTION
On OpenShift, we don't have permission to write to files in the container fs.