### PR TITLE
Prune unmanaged resources

### DIFF
--- a/controllers/tempo/tempostack_controller.go
+++ b/controllers/tempo/tempostack_controller.go
@@ -15,6 +15,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -178,7 +179,16 @@ func (r *TempoStackReconciler) reconcileManifests(ctx context.Context, log logr.
 
 	}
 
-	objects, err := manifests.BuildAll(manifestutils.Params{
+	// Collect all objects owned by the operator, to be able to prune objects
+	// which exist in the cluster but are not managed by the operator anymore.
+	// For example, when the Jaeger Query Ingress is enabled and later disabled,
+	// the Ingress object should be removed from the cluster.
+	pruneObjects, err := r.findObjectsOwnedByTempoOperator(ctx, tempo)
+	if err != nil {
+		return err
+	}
+
+	managedObjects, err := manifests.BuildAll(manifestutils.Params{
 		Tempo:         tempo,
 		StorageParams: *storageConfig,
 		Gates:         r.FeatureGates,
@@ -190,7 +200,7 @@ func (r *TempoStackReconciler) reconcileManifests(ctx context.Context, log logr.
 	}
 
 	errCount := 0
-	for _, obj := range objects {
+	for _, obj := range managedObjects {
 		l := log.WithValues(
 			"object_name", obj.GetName(),
 			"object_kind", obj.GetObjectKind(),
@@ -215,11 +225,33 @@ func (r *TempoStackReconciler) reconcileManifests(ctx context.Context, log logr.
 			continue
 		}
 
-		l.Info(fmt.Sprintf("Resource has been %s", op))
+		l.Info(fmt.Sprintf("resource has been %s", op))
+
+		// This object is still managed by the operator, remove it from the list of objects to prune
+		delete(pruneObjects, obj.GetUID())
 	}
 
 	if errCount > 0 {
-		return fmt.Errorf("failed to create objects for Tempo %s", req.NamespacedName)
+		return fmt.Errorf("failed to create objects for TempoStack %s", req.NamespacedName)
+	}
+
+	// Prune owned objects in the cluster which are not managed anymore.
+	pruneErrCount := 0
+	for _, obj := range pruneObjects {
+		l := log.WithValues(
+			"object_name", obj.GetName(),
+			"object_kind", obj.GetObjectKind(),
+		)
+		l.Info("pruning unmanaged resource")
+
+		err = r.Delete(ctx, obj)
+		if err != nil {
+			l.Error(err, "failed to delete resource")
+			pruneErrCount++
+		}
+	}
+	if pruneErrCount > 0 {
+		return fmt.Errorf("failed to prune objects of TempoStack %s", req.NamespacedName)
 	}
 
 	return nil
@@ -315,6 +347,39 @@ func (r *TempoStackReconciler) findTempoStackForStorageSecret(secret client.Obje
 		}
 	}
 	return requests
+}
+
+func (r *TempoStackReconciler) findObjectsOwnedByTempoOperator(ctx context.Context, tempo v1alpha1.TempoStack) (map[types.UID]client.Object, error) {
+	ownedObjects := map[types.UID]client.Object{}
+	listOps := &client.ListOptions{
+		Namespace:     tempo.GetNamespace(),
+		LabelSelector: labels.SelectorFromSet(manifestutils.CommonLabels(tempo.Name)),
+	}
+
+	// Add all resources where the operator can conditionally create an object.
+	// For example, Ingress and Route can be enabled or disabled in the CR.
+
+	ingressList := &networkingv1.IngressList{}
+	err := r.List(ctx, ingressList, listOps)
+	if err != nil {
+		return nil, fmt.Errorf("error listing ingress: %w", err)
+	}
+	for i := range ingressList.Items {
+		ownedObjects[ingressList.Items[i].GetUID()] = &ingressList.Items[i]
+	}
+
+	if r.FeatureGates.OpenShift.OpenShiftRoute {
+		routesList := &routev1.RouteList{}
+		err := r.List(ctx, routesList, listOps)
+		if err != nil {
+			return nil, fmt.Errorf("error listing ingress: %w", err)
+		}
+		for i := range routesList.Items {
+			ownedObjects[routesList.Items[i].GetUID()] = &routesList.Items[i]
+		}
+	}
+
+	return ownedObjects, nil
 }
 
 // GetPodsComponent is used for fetching component pod status and refreshing the status of the CR.

--- a/controllers/tempo/tempostack_controller.go
+++ b/controllers/tempo/tempostack_controller.go
@@ -372,7 +372,7 @@ func (r *TempoStackReconciler) findObjectsOwnedByTempoOperator(ctx context.Conte
 		routesList := &routev1.RouteList{}
 		err := r.List(ctx, routesList, listOps)
 		if err != nil {
-			return nil, fmt.Errorf("error listing ingress: %w", err)
+			return nil, fmt.Errorf("error listing routes: %w", err)
 		}
 		for i := range routesList.Items {
 			ownedObjects[routesList.Items[i].GetUID()] = &routesList.Items[i]

--- a/controllers/tempo/tempostack_controller_test.go
+++ b/controllers/tempo/tempostack_controller_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -418,4 +420,75 @@ func TestTLSEnable(t *testing.T) {
 		}
 		assert.Contains(t, names, fmt.Sprintf("tempo-%s-ca-bundle", nsn.Name))
 	}
+}
+
+func TestPruneIngress(t *testing.T) {
+	// Create object storage secret and Tempo CR
+	nsn := types.NamespacedName{Name: "prune-ingress-test", Namespace: "default"}
+	storageSecret := createSecret(t, nsn)
+	tempo := &v1alpha1.TempoStack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nsn.Name,
+			Namespace: nsn.Namespace,
+		},
+		Spec: v1alpha1.TempoStackSpec{
+			Images: configv1alpha1.ImagesSpec{
+				Tempo:      "docker.io/grafana/tempo:1.5.0",
+				TempoQuery: "docker.io/grafana/tempo-query:1.5.0",
+			},
+			Storage: v1alpha1.ObjectStorageSpec{
+				Secret: storageSecret.Name,
+			},
+			Components: v1alpha1.TempoComponentsSpec{
+				QueryFrontend: v1alpha1.TempoQueryFrontendSpec{
+					JaegerQuery: v1alpha1.JaegerQuerySpec{
+						Enabled: true,
+						Ingress: v1alpha1.JaegerQueryIngressSpec{
+							Type: v1alpha1.IngressTypeIngress,
+						},
+					},
+				},
+			},
+		},
+	}
+	err := k8sClient.Create(context.Background(), tempo)
+	require.NoError(t, err)
+
+	// Reconcile
+	reconciler := TempoStackReconciler{
+		Client: k8sClient,
+		Scheme: testScheme,
+		FeatureGates: configv1alpha1.FeatureGates{
+			TLSProfile: string(configv1alpha1.TLSProfileIntermediateType),
+		},
+	}
+	req := ctrl.Request{
+		NamespacedName: nsn,
+	}
+	reconcileResult, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, false, reconcileResult.Requeue)
+
+	// Verify Ingress is created
+	ingressNsn := types.NamespacedName{Name: "tempo-prune-ingress-test-query-frontend", Namespace: "default"}
+	ingress := networkingv1.Ingress{}
+	err = k8sClient.Get(context.Background(), ingressNsn, &ingress)
+	require.NoError(t, err)
+
+	// Disable Ingress in CR
+	err = k8sClient.Get(context.Background(), nsn, tempo) // operator modified CR, fetch latest version
+	require.NoError(t, err)
+	tempo.Spec.Components.QueryFrontend.JaegerQuery.Ingress.Type = v1alpha1.IngressTypeNone
+	err = k8sClient.Update(context.Background(), tempo)
+	require.NoError(t, err)
+
+	// Reconcile
+	reconcileResult, err = reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, false, reconcileResult.Requeue)
+
+	// Verify Ingress got deleted
+	err = k8sClient.Get(context.Background(), ingressNsn, &ingress)
+	require.Error(t, err)
+	require.Equal(t, metav1.StatusReasonNotFound, err.(*errors.StatusError).ErrStatus.Reason)
 }


### PR DESCRIPTION
Prune objects which exist in the cluster but are not managed by the operator anymore. For example, when the Jaeger Query Ingress is enabled and later disabled, the Ingress object should be removed from the cluster.

Resolves: #259