### PR TITLE
Set default TLSProfile and validate ProjectConfig

### DIFF
--- a/apis/config/v1alpha1/projectconfig_types.go
+++ b/apis/config/v1alpha1/projectconfig_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cfg "sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 )
@@ -143,4 +145,17 @@ type ProjectConfig struct {
 
 func init() {
 	SchemeBuilder.Register(&ProjectConfig{})
+}
+
+func (c *ProjectConfig) Validate() error {
+	switch c.Gates.TLSProfile {
+	case string(TLSProfileOldType),
+		string(TLSProfileIntermediateType),
+		string(TLSProfileModernType):
+		// valid setting
+	default:
+		return fmt.Errorf("invalid value '%s' for setting featureGates.tlsProfile (valid values: %s, %s and %s)", c.Gates.TLSProfile, TLSProfileOldType, TLSProfileIntermediateType, TLSProfileModernType)
+	}
+
+	return nil
 }

--- a/apis/config/v1alpha1/projectconfig_types.go
+++ b/apis/config/v1alpha1/projectconfig_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"fmt"
 
+	dockerparser "github.com/novln/docker-parser"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cfg "sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 )
@@ -156,6 +157,25 @@ func (c *ProjectConfig) Validate() error {
 		// valid setting
 	default:
 		return fmt.Errorf("invalid value '%s' for setting featureGates.tlsProfile (valid values: %s, %s and %s)", c.Gates.TLSProfile, TLSProfileOldType, TLSProfileIntermediateType, TLSProfileModernType)
+	}
+
+	if c.DefaultImages.Tempo != "" {
+		_, err := dockerparser.Parse(c.DefaultImages.Tempo)
+		if err != nil {
+			return fmt.Errorf("invalid value '%s' for setting images.tempo", c.DefaultImages.Tempo)
+		}
+	}
+	if c.DefaultImages.TempoQuery != "" {
+		_, err := dockerparser.Parse(c.DefaultImages.TempoQuery)
+		if err != nil {
+			return fmt.Errorf("invalid value '%s' for setting images.tempoQuery", c.DefaultImages.TempoQuery)
+		}
+	}
+	if c.DefaultImages.TempoGateway != "" {
+		_, err := dockerparser.Parse(c.DefaultImages.TempoGateway)
+		if err != nil {
+			return fmt.Errorf("invalid value '%s' for setting images.tempoGateway", c.DefaultImages.TempoGateway)
+		}
 	}
 
 	return nil

--- a/apis/config/v1alpha1/projectconfig_types.go
+++ b/apis/config/v1alpha1/projectconfig_types.go
@@ -147,6 +147,7 @@ func init() {
 	SchemeBuilder.Register(&ProjectConfig{})
 }
 
+// Validate validates the controller configuration (ProjectConfig).
 func (c *ProjectConfig) Validate() error {
 	switch c.Gates.TLSProfile {
 	case string(TLSProfileOldType),

--- a/apis/config/v1alpha1/projectconfig_types_test.go
+++ b/apis/config/v1alpha1/projectconfig_types_test.go
@@ -36,6 +36,42 @@ func TestValidateProjectConfig(t *testing.T) {
 			input:    ProjectConfig{},
 			expected: errors.New("invalid value '' for setting featureGates.tlsProfile (valid values: Old, Intermediate and Modern)"),
 		},
+		{
+			name: "invalid tempo container image",
+			input: ProjectConfig{
+				DefaultImages: ImagesSpec{
+					Tempo: "abc@def",
+				},
+				Gates: FeatureGates{
+					TLSProfile: "Modern",
+				},
+			},
+			expected: errors.New("invalid value 'abc@def' for setting images.tempo"),
+		},
+		{
+			name: "invalid tempoQuery container image",
+			input: ProjectConfig{
+				DefaultImages: ImagesSpec{
+					TempoQuery: "abc@def",
+				},
+				Gates: FeatureGates{
+					TLSProfile: "Modern",
+				},
+			},
+			expected: errors.New("invalid value 'abc@def' for setting images.tempoQuery"),
+		},
+		{
+			name: "invalid tempoGateway container image",
+			input: ProjectConfig{
+				DefaultImages: ImagesSpec{
+					TempoGateway: "abc@def",
+				},
+				Gates: FeatureGates{
+					TLSProfile: "Modern",
+				},
+			},
+			expected: errors.New("invalid value 'abc@def' for setting images.tempoGateway"),
+		},
 	}
 
 	for _, test := range tests {

--- a/apis/config/v1alpha1/projectconfig_types_test.go
+++ b/apis/config/v1alpha1/projectconfig_types_test.go
@@ -1,0 +1,46 @@
+package v1alpha1
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateProjectConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    ProjectConfig
+		expected error
+	}{
+		{
+			name: "valid featureGates.tlsProfile setting",
+			input: ProjectConfig{
+				Gates: FeatureGates{
+					TLSProfile: string(TLSProfileModernType),
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "invalid featureGates.tlsProfile setting",
+			input: ProjectConfig{
+				Gates: FeatureGates{
+					TLSProfile: "abc",
+				},
+			},
+			expected: errors.New("invalid value 'abc' for setting featureGates.tlsProfile (valid values: Old, Intermediate and Modern)"),
+		},
+		{
+			name:     "empty featureGates.tlsProfile setting",
+			input:    ProjectConfig{},
+			expected: errors.New("invalid value '' for setting featureGates.tlsProfile (valid values: Old, Intermediate and Modern)"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.input.Validate())
+		})
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	configv1alpha1 "github.com/os-observability/tempo-operator/apis/config/v1alpha1"
+)
+
+func TestReadConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected configv1alpha1.ProjectConfig
+		err      string
+	}{
+		{
+			name:  "no featureGates.tlsProfile given, using default value",
+			input: "testdata/empty.yaml",
+			expected: configv1alpha1.ProjectConfig{
+				Gates: configv1alpha1.FeatureGates{
+					TLSProfile: string(configv1alpha1.TLSProfileModernType),
+				},
+			},
+		},
+		{
+			name:  "featureGates.tlsProfile given, not using default value",
+			input: "testdata/tlsprofile_old.yaml",
+			expected: configv1alpha1.ProjectConfig{
+				Gates: configv1alpha1.FeatureGates{
+					TLSProfile: string(configv1alpha1.TLSProfileOldType),
+				},
+			},
+		},
+		{
+			name:  "invalid featureGates.tlsProfile given, show error",
+			input: "testdata/tlsprofile_invalid.yaml",
+			err:   "controller config validation failed: invalid value 'abc' for setting featureGates.tlsProfile (valid values: Old, Intermediate and Modern)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.SetContext(context.Background())
+
+			err := readConfig(cmd, test.input)
+			if test.err == "" {
+				require.NoError(t, err)
+
+				rootCmdConfig := cmd.Context().Value(RootConfigKey{}).(RootConfig)
+				assert.Equal(t, test.expected, rootCmdConfig.CtrlConfig)
+			} else {
+				require.Error(t, err)
+				require.Equal(t, test.err, err.Error())
+			}
+		})
+	}
+}

--- a/cmd/testdata/tlsprofile_invalid.yaml
+++ b/cmd/testdata/tlsprofile_invalid.yaml
@@ -1,0 +1,2 @@
+featureGates:
+  tlsProfile: abc

--- a/cmd/testdata/tlsprofile_old.yaml
+++ b/cmd/testdata/tlsprofile_old.yaml
@@ -1,0 +1,2 @@
+featureGates:
+  tlsProfile: Old


### PR DESCRIPTION
Resolves: #266

We don't need a dedicated Default() function, as we can just set default values in `root.go` when we create an instance of `ProjectConfig`