### PR TITLE
Do not fail CI if codecov step fails

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -32,7 +32,7 @@ jobs:
           files: cover.out
           flags: unittests
           name: codecov-tempo-operator
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
 
   security:


### PR DESCRIPTION
Unfortunately codecov is flaky lately, and it shouldn't affect the result of the unit test action.